### PR TITLE
Saving to yaml

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -14,7 +14,8 @@
     "@mui/joy": "^5.0.0-beta.11",
     "next": "13.5.6",
     "react": "^18",
-    "react-dom": "^18"
+    "react-dom": "^18",
+    "yaml": "^2.3.3"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/webapp/src/app/[lang]/page.tsx
+++ b/webapp/src/app/[lang]/page.tsx
@@ -39,6 +39,26 @@ export default function Home({ params }: { params: { lang: string } }) {
             <MessageForm
               key={msg.id}
               message={msg}
+              onSave={async (text) => {
+                const res = await fetch(
+                  `/api/translations/${params.lang}/${msg.id}`,
+                  {
+                    method: "PUT",
+                    headers: {
+                      "Content-Type": "application/json",
+                    },
+                    body: JSON.stringify({
+                      text,
+                    }),
+                  },
+                );
+
+                const payload = await res.json();
+                setTranslations((cur) => ({
+                  ...cur,
+                  [msg.id]: text,
+                }));
+              }}
               translation={translations[msg.id] || ""}
             />
           );

--- a/webapp/src/app/api/translations/[lang]/[msgId]/route.ts
+++ b/webapp/src/app/api/translations/[lang]/[msgId]/route.ts
@@ -1,0 +1,42 @@
+import { parse, stringify } from "yaml";
+import fs from "fs/promises";
+import { NextRequest, NextResponse } from "next/server";
+
+const { REPO_PATH } = process.env;
+
+export async function PUT(
+  req: NextRequest,
+  context: { params: { lang: string; msgId: string } },
+) {
+  const payload = await req.json();
+  const { lang, msgId } = context.params;
+  const { text } = payload;
+
+  const yamlPath = REPO_PATH + `/src/locale/${lang}.yml`;
+
+  const yamlBuf = await fs.readFile(yamlPath);
+  const translations = parse(yamlBuf.toString());
+
+  const objKeyPath = msgId.split(".");
+  let curObj = translations;
+  objKeyPath.forEach((key, index) => {
+    if (index == objKeyPath.length - 1) {
+      curObj[key] = text;
+    } else {
+      curObj[key] = { ...curObj[key] };
+      curObj = curObj[key] as Record<string, unknown>;
+    }
+  });
+
+  const yamlOutput = stringify(translations, {
+    singleQuote: true,
+    doubleQuotedAsJSON: true,
+  });
+  await fs.writeFile(yamlPath, yamlOutput);
+
+  return NextResponse.json({
+    lang,
+    msgId,
+    text,
+  });
+}

--- a/webapp/src/components/MessageForm.tsx
+++ b/webapp/src/components/MessageForm.tsx
@@ -48,6 +48,11 @@ const MessageForm: FC<Props> = ({ message, onSave, translation }) => {
             sx={{ flexGrow: 1 }}
           />
           {edited && <Button onClick={() => onSave(text)}>Save</Button>}
+          {edited && (
+            <Button variant="outlined" onClick={() => setText(translation)}>
+              ↺
+            </Button>
+          )}
         </Box>
         {!!message.params.length && (
           <Box>

--- a/webapp/src/components/MessageForm.tsx
+++ b/webapp/src/components/MessageForm.tsx
@@ -1,18 +1,29 @@
 import { MessageData } from "@/utils/readTypedMessages";
-import { Box, Grid, List, ListItem, Textarea, Typography } from "@mui/joy";
+import {
+  Box,
+  Button,
+  Grid,
+  List,
+  ListItem,
+  Textarea,
+  Typography,
+} from "@mui/joy";
 import { FC, useEffect, useState } from "react";
 
 type Props = {
   message: MessageData;
+  onSave: (text: string) => void;
   translation: string;
 };
 
-const MessageForm: FC<Props> = ({ message, translation }) => {
+const MessageForm: FC<Props> = ({ message, onSave, translation }) => {
   const [text, setText] = useState(translation);
 
   useEffect(() => {
     setText(translation);
   }, [translation]);
+
+  const edited = text != translation;
 
   return (
     <Grid
@@ -33,7 +44,10 @@ const MessageForm: FC<Props> = ({ message, translation }) => {
           <Textarea
             value={text}
             minRows={2}
+            onChange={(ev) => setText(ev.target.value)}
+            sx={{ flexGrow: 1 }}
           />
+          {edited && <Button onClick={() => onSave(text)}>Save</Button>}
         </Box>
         {!!message.params.length && (
           <Box>

--- a/webapp/yarn.lock
+++ b/webapp/yarn.lock
@@ -2563,6 +2563,11 @@ yaml@^1.10.0:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
+yaml@^2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.3.3.tgz#01f6d18ef036446340007db8e016810e5d64aad9"
+  integrity sha512-zw0VAJxgeZ6+++/su5AFoqBbZbrEakwu+X0M5HmcwUiBL7AzcuPKjj5we4xfQLp78LkEMpD0cOnUhmgOVy3KdQ==
+
 yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"


### PR DESCRIPTION
This PR implements saving directly to YAML. There are some issues with this, specifically the risk for race conditions. Ideally, there should be an intermediate step to save in memory before saving to YAML (which should happen periodically or when an admin triggers it).

But this is a nice proof of concept and early implementation for this functionality, which is a major improvement compared to how translate.zetkin.org works.

<img width="1377" alt="image" src="https://github.com/zetkin/lyra/assets/550212/c6974801-e4bd-4aca-b1bd-360076480cfe">
