### PR TITLE
Restore fs after each in YamlTranslationAdapter

### DIFF
--- a/webapp/src/utils/adapters/YamlTranslationAdapter.spec.ts
+++ b/webapp/src/utils/adapters/YamlTranslationAdapter.spec.ts
@@ -1,9 +1,13 @@
 import mock from 'mock-fs';
 import YamlTranslationAdapter from './YamlTranslationAdapter';
-import { describe, expect, it } from '@jest/globals';
+import { afterEach, describe, expect, it } from '@jest/globals';
 
 describe('YamlTranslationAdapter', () => {
   describe('getTranslations()', () => {
+    afterEach(() => {
+      mock.restore();
+    });
+
     it('Reads translations for multiple languages', async () => {
       mock({
         '/path/to/repo/locale/de.yml': 'no: Nein',


### PR DESCRIPTION
In https://github.com/zetkin/lyra/pull/49 we were seeing some seemingly random ENOENT. I am guessing these were caused by the missing mock.restore in this spec. Note that all out other usages of mock-fs restore like this.

I considered adding the afterEach at the root-describe instead to reduce risk of missing the restore if later use is added outside the inner describe. In the end, I opted for keeping it closer to the usage. I am not sure how safe it is to restore when you have not set up any mock.