### PR TITLE
Move baseBranch config from lyraConfig to ServerConfig

### DIFF
--- a/webapp/README.md
+++ b/webapp/README.md
@@ -8,6 +8,7 @@ In the root folder create file `./config/projects.yaml` with example content:
 projects:
   - name: example-unique-name
     repo_path: /Users/username/fooRepo # absolute path to repo
+    base_branch: main
     project_path: . # relative path of project from repo_path
     owner: amerharb
     repo: zetkin.app.zetkin.org
@@ -19,7 +20,6 @@ file `lyra.yml` with the
 example content:
 
 ```yaml
-baseBranch: main
 projects:
   - path: . # relative path to project in repo
     messages:

--- a/webapp/src/Cache.ts
+++ b/webapp/src/Cache.ts
@@ -17,6 +17,7 @@ export class Cache {
     const serverProjectConfig =
       await ServerConfig.getProjectConfig(projectName);
     const repoPath = serverProjectConfig.repoPath;
+    await Cache.gitPullIfNeeded(repoPath, serverProjectConfig.baseBranch);
     const lyraConfig = await LyraConfig.readFromDir(repoPath);
     const lyraProjectConfig = lyraConfig.getProjectConfigByPath(
       serverProjectConfig.projectPath,
@@ -24,7 +25,6 @@ export class Cache {
     if (!lyraProjectConfig.isLanguageSupported(lang)) {
       throw new LanguageNotSupported(lang, projectName);
     }
-    await Cache.gitPullIfNeeded(repoPath, lyraConfig.baseBranch);
     const store = await Cache.getProjectStore(lyraProjectConfig);
     return store.getTranslations(lang);
   }

--- a/webapp/src/RepoGit.ts
+++ b/webapp/src/RepoGit.ts
@@ -96,10 +96,9 @@ export class RepoGit {
   }
 
   private async getLyraConfig(): Promise<LyraConfig> {
-    if (this.lyraConfig) {
-      return this.lyraConfig;
+    if (this.lyraConfig === undefined) {
+      this.lyraConfig = await LyraConfig.readFromDir(this.spConfig.repoPath);
     }
-    this.lyraConfig = await LyraConfig.readFromDir(this.spConfig.repoPath);
     return this.lyraConfig;
   }
 

--- a/webapp/src/app/api/pull-request/[projectName]/route.ts
+++ b/webapp/src/app/api/pull-request/[projectName]/route.ts
@@ -37,7 +37,7 @@ export async function POST(
 
   try {
     syncLock.set(repoPath, true);
-    const repoGit = new RepoGit(repoPath);
+    const repoGit = new RepoGit(serverProjectConfig);
     const baseBranch = await repoGit.checkoutBaseAndPull();
     const langFilePaths = await repoGit.saveLanguageFiles(
       serverProjectConfig.projectPath,

--- a/webapp/src/errors.ts
+++ b/webapp/src/errors.ts
@@ -17,8 +17,14 @@ export class MessageNotFound extends Error {
 }
 
 export class LyraConfigReadingError extends Error {
-  constructor(filename: string) {
-    super(`Error reading file: [${filename}]`);
+  constructor(filename: string, error?: unknown) {
+    if (error instanceof Error) {
+      super(
+        `Error reading file: [${filename}], error message:${error.message}`,
+      );
+    } else {
+      super(`Error reading file: [${filename}]`);
+    }
   }
 }
 
@@ -41,10 +47,7 @@ export class ProjectNameNotFoundError extends Error {
 }
 
 export class WriteLanguageFileError extends Error {
-  constructor(
-    public langFilename: string,
-    public error: unknown,
-  ) {
+  constructor(public langFilename: string) {
     super(`Error writing language file: [${langFilename}]`);
   }
 }

--- a/webapp/src/errors.ts
+++ b/webapp/src/errors.ts
@@ -47,7 +47,10 @@ export class ProjectNameNotFoundError extends Error {
 }
 
 export class WriteLanguageFileError extends Error {
-  constructor(public langFilename: string) {
+  constructor(
+    public langFilename: string,
+    public error: unknown,
+  ) {
     super(`Error writing language file: [${langFilename}]`);
   }
 }

--- a/webapp/src/errors.ts
+++ b/webapp/src/errors.ts
@@ -51,7 +51,10 @@ export class WriteLanguageFileError extends Error {
     public langFilename: string,
     public error: unknown,
   ) {
-    super(`Error writing language file: [${langFilename}]`);
+    const errorMessage =
+      error instanceof Error ? ', error message: ' + error.message : '';
+
+    super(`Error writing language file: [${langFilename}]${errorMessage}`);
   }
 }
 

--- a/webapp/src/utils/lyraConfig.spec.ts
+++ b/webapp/src/utils/lyraConfig.spec.ts
@@ -29,7 +29,6 @@ describe('LyraConfig', () => {
       expect(config.projects[0].absTranslationsPath).toEqual(
         '/path/to/repo/locale',
       );
-      expect(config.baseBranch).toEqual('main'); // default value
       expect(config.projects[0].languages).toEqual(['en']); // default value
     });
 
@@ -53,24 +52,6 @@ describe('LyraConfig', () => {
       expect(config.projects[0].absTranslationsPath).toEqual(
         '/path/to/repo/project/locale',
       );
-    });
-
-    it('reads baseBranch', async () => {
-      mock({
-        '/path/to/repo/lyra.yml': [
-          'baseBranch: branch1',
-          'projects:',
-          '- path: project',
-          '  messages:',
-          '    format: ts',
-          '    path: anyValue',
-          '  translations:',
-          '    path: anyValue',
-        ].join('\n'),
-      });
-
-      const config = await LyraConfig.readFromDir('/path/to/repo');
-      expect(config.baseBranch).toEqual('branch1');
     });
 
     it('reads more than one projects', async () => {
@@ -129,7 +110,6 @@ describe('LyraConfig', () => {
         expect.assertions(1);
         mock({
           '/path/to/repo/lyra.yml': [
-            'baseBranch: branch1',
             'projects:',
             '- path: project',
             '  messages:',
@@ -146,7 +126,6 @@ describe('LyraConfig', () => {
         expect.assertions(1);
         mock({
           '/path/to/repo/xxx.yml': [
-            'baseBranch: branch1',
             'projects:',
             '- path: project',
             '  messages:',
@@ -180,7 +159,6 @@ describe('LyraConfig', () => {
       expect(projectConfig.messageKind).toEqual(MessageKind.YAML);
       expect(projectConfig.absMessagesPath).toEqual('/path/to/repo/locale');
       expect(projectConfig.absTranslationsPath).toEqual('/path/to/repo/locale');
-      expect(config.baseBranch).toEqual('main'); // default value
       expect(projectConfig.languages).toEqual(['en']); // default value
     });
     it('reads message kind and path from lyra.yml', async () => {
@@ -202,7 +180,6 @@ describe('LyraConfig', () => {
       expect(projectConfig.absTranslationsPath).toEqual(
         '/path/to/repo/foo/locale',
       );
-      expect(config.baseBranch).toEqual('main'); // default value
     });
 
     it('reads message kind and path from lyra.yml with multi projects', async () => {
@@ -239,7 +216,6 @@ describe('LyraConfig', () => {
       expect(projectConfig2.absTranslationsPath).toEqual(
         '/path/to/repo/foo2/locale2',
       );
-      expect(config.baseBranch).toEqual('main'); // default value
     });
 
     it('reads languages from lyra.yml with multi projects', async () => {
@@ -280,7 +256,6 @@ describe('LyraConfig', () => {
       it('throws for for invalid project path', async () => {
         mock({
           '/path/to/repo/lyra.yml': [
-            'baseBranch: branch1',
             'projects:',
             '- path: project',
             '  messages:',

--- a/webapp/src/utils/lyraConfig.spec.ts
+++ b/webapp/src/utils/lyraConfig.spec.ts
@@ -122,6 +122,24 @@ describe('LyraConfig', () => {
         await expect(actual).rejects.toThrow(LyraConfigReadingError);
       });
 
+      it('throws for define deprecated property baseBranch', async () => {
+        expect.assertions(1);
+        mock({
+          '/path/to/repo/lyra.yml': [
+            'baseBranch: anyValue', // deprecated
+            'projects:',
+            '- path: project',
+            '  messages:',
+            '    format: ts',
+            '    path: anyValue',
+            '  translations:',
+            '    path: anyValue',
+          ].join('\n'),
+        });
+        const actual = LyraConfig.readFromDir('/path/to/repo');
+        await expect(actual).rejects.toThrow(LyraConfigReadingError);
+      });
+
       it('throws for file not found', async () => {
         expect.assertions(1);
         mock({

--- a/webapp/src/utils/lyraConfig.ts
+++ b/webapp/src/utils/lyraConfig.ts
@@ -67,7 +67,7 @@ export class LyraConfig {
         }),
       );
     } catch (e) {
-      throw new LyraConfigReadingError(filename);
+      throw new LyraConfigReadingError(filename, e);
     }
   }
 }

--- a/webapp/src/utils/lyraConfig.ts
+++ b/webapp/src/utils/lyraConfig.ts
@@ -15,7 +15,8 @@ const KIND_BY_FORMAT_VALUE: Record<'ts' | 'yaml', MessageKind> = {
 };
 
 const lyraConfigSchema = z.object({
-  baseBranch: z.optional(z.string()),
+  /** @deprecated baseBranch has been moved to serverConfigSchema as base_branch */
+  baseBranch: z.undefined(),
   projects: z.array(
     z.object({
       languages: z.optional(z.array(z.string()).min(1)),

--- a/webapp/src/utils/lyraConfig.ts
+++ b/webapp/src/utils/lyraConfig.ts
@@ -32,10 +32,7 @@ const lyraConfigSchema = z.object({
 });
 
 export class LyraConfig {
-  private constructor(
-    public readonly projects: LyraProjectConfig[],
-    public readonly baseBranch: string, // following GitHub terminology target branch called base branch
-  ) {}
+  private constructor(public readonly projects: LyraProjectConfig[]) {}
 
   public getProjectConfigByPath(projectPath: string): LyraProjectConfig {
     const projectConfig = this.projects.find(
@@ -67,7 +64,6 @@ export class LyraConfig {
             project.languages ?? ['en'], // default language to be english if not provided
           );
         }),
-        parsed.baseBranch ?? 'main', // default base branch to be main if not provided
       );
     } catch (e) {
       throw new LyraConfigReadingError(filename);

--- a/webapp/src/utils/serverConfig.spec.ts
+++ b/webapp/src/utils/serverConfig.spec.ts
@@ -14,6 +14,7 @@ describe('ServerConfig', () => {
           'projects:',
           '  - name: foo',
           '    repo_path: /path/to/repo',
+          '    base_branch: fooBranch',
           '    project_path: ./project',
           '    owner: owner',
           '    repo: app.zetkin.org',
@@ -23,6 +24,7 @@ describe('ServerConfig', () => {
       const config = await ServerConfig.read();
       expect(config.projects[0].name).toEqual('foo');
       expect(config.projects[0].repoPath).toEqual('/path/to/repo');
+      expect(config.projects[0].baseBranch).toEqual('fooBranch');
       expect(config.projects[0].projectPath).toEqual('project'); // Note: path changed after normalization
       expect(config.projects[0].owner).toEqual('owner');
       expect(config.projects[0].repo).toEqual('app.zetkin.org');
@@ -99,6 +101,7 @@ describe('ServerConfig', () => {
       });
       const projectConfig = await ServerConfig.getProjectConfig('bar');
       expect(projectConfig.repoPath).toEqual('/path/to/repo');
+      expect(projectConfig.baseBranch).toEqual('main'); // Note: default value when missed in config
       expect(projectConfig.projectPath).toEqual('project2');
     });
 

--- a/webapp/src/utils/serverConfig.ts
+++ b/webapp/src/utils/serverConfig.ts
@@ -7,6 +7,7 @@ import { ProjectNameNotFoundError, ServerConfigReadingError } from '@/errors';
 const serverConfigSchema = z.object({
   projects: z.array(
     z.object({
+      base_branch: z.string().optional(),
       github_token: z.string(),
       name: z.string(),
       owner: z.string(),
@@ -45,6 +46,7 @@ export class ServerConfig {
           return new ServerProjectConfig(
             project.name,
             path.normalize(project.repo_path),
+            project.base_branch ?? 'main',
             path.normalize(project.project_path),
             project.owner,
             project.repo,
@@ -70,6 +72,8 @@ export class ServerProjectConfig {
     public readonly name: string,
     /** absolute local path to repo */
     public readonly repoPath: string,
+    /** following GitHub terminology target branch called base branch */
+    public readonly baseBranch: string,
     /** relative path of project from repo_path */
     public readonly projectPath: string,
     public readonly owner: string,


### PR DESCRIPTION
Having baseBranch config in LyraConfig is not correct, because:

1. Lets say the setting baseBranch is changed from `main` to `prod` the local copy of Lyra has value of `main` and accordingly will always pull from that branch while the new baseBranch in prod containt different value

2. If we are cloning the repo from remote for the first time (we never test this yet) Lyra will throw Exception since it need to read LyraConfig to have the value of baseBranch that is needed to checkout but at the same time there is no local copy to read from

Solution: move this settings to ServerConfig