### PR TITLE
Make sure we have pulled before reading LyraConfig

### DIFF
--- a/webapp/README.md
+++ b/webapp/README.md
@@ -15,7 +15,11 @@ projects:
     github_token: << github token >>
 ```
 
-also the project repository (client repository) needs to be cloned locally. and has in the root folder config
+Multiple projects are supported, and multiple projects in the same local git repository
+are supported, but configuring multiple porjects with different `repo_path`, resolving to
+same local git repository, is _not_ supported.
+
+The project repository (client repository) needs to be cloned locally. and has in the root folder config
 file `lyra.yml` with the
 example content:
 

--- a/webapp/src/Cache.ts
+++ b/webapp/src/Cache.ts
@@ -1,26 +1,19 @@
 /* global globalThis */
 
-import { debug } from '@/utils/log';
-import { IGit } from '@/utils/git/IGit';
+import { getRepoGit } from '@/RepoGit';
 import { LanguageNotSupported } from '@/errors';
+import { LyraProjectConfig } from '@/utils/lyraConfig';
 import { ProjectStore } from '@/store/ProjectStore';
-import { RepoGit } from '@/RepoGit';
-import { SimpleGitWrapper } from '@/utils/git/SimpleGitWrapper';
+import { ServerConfig } from '@/utils/serverConfig';
 import { Store } from '@/store/Store';
 import YamlTranslationAdapter from '@/utils/adapters/YamlTranslationAdapter';
-import { LyraConfig, LyraProjectConfig } from '@/utils/lyraConfig';
-import { ServerConfig, ServerProjectConfig } from '@/utils/serverConfig';
 
 export class Cache {
-  private static hasPulled = new Set<string>();
-
   public static async getLanguage(projectName: string, lang: string) {
     const serverProjectConfig =
       await ServerConfig.getProjectConfig(projectName);
-    await Cache.gitPullIfNeeded(serverProjectConfig);
-    const lyraConfig = await LyraConfig.readFromDir(
-      serverProjectConfig.repoPath,
-    );
+    const repo = await getRepoGit(serverProjectConfig);
+    const lyraConfig = await repo.getLyraConfig();
     const lyraProjectConfig = lyraConfig.getProjectConfigByPath(
       serverProjectConfig.projectPath,
     );
@@ -46,22 +39,5 @@ export class Cache {
     }
 
     return globalThis.store.getProjectStore(lyraProjectConfig.absPath);
-  }
-
-  private static async gitPullIfNeeded(spConfig: ServerProjectConfig) {
-    const { repoPath, baseBranch } = spConfig;
-    if (Cache.hasPulled.has(repoPath)) {
-      debug(`repoPath: ${repoPath} is already pulled`);
-      return;
-    }
-    await RepoGit.cloneIfNotExist(spConfig);
-    debug(`prepare git options for path: ${repoPath}`);
-    const git: IGit = new SimpleGitWrapper(repoPath);
-    debug(`git checkout ${baseBranch} branch...`);
-    await git.checkout(baseBranch);
-    debug('git pull...');
-    await git.pull();
-    debug(`git done checkout ${baseBranch} branch and pull`);
-    Cache.hasPulled.add(repoPath);
   }
 }

--- a/webapp/src/Cache.ts
+++ b/webapp/src/Cache.ts
@@ -1,9 +1,9 @@
 /* global globalThis */
 
-import { getRepoGit } from '@/RepoGit';
 import { LanguageNotSupported } from '@/errors';
 import { LyraProjectConfig } from '@/utils/lyraConfig';
 import { ProjectStore } from '@/store/ProjectStore';
+import { RepoGit } from '@/RepoGit';
 import { ServerConfig } from '@/utils/serverConfig';
 import { Store } from '@/store/Store';
 import YamlTranslationAdapter from '@/utils/adapters/YamlTranslationAdapter';
@@ -12,8 +12,8 @@ export class Cache {
   public static async getLanguage(projectName: string, lang: string) {
     const serverProjectConfig =
       await ServerConfig.getProjectConfig(projectName);
-    const repo = await getRepoGit(serverProjectConfig);
-    const lyraConfig = await repo.getLyraConfig();
+    const repoGit = await RepoGit.getRepoGit(serverProjectConfig);
+    const lyraConfig = await repoGit.getLyraConfig();
     const lyraProjectConfig = lyraConfig.getProjectConfigByPath(
       serverProjectConfig.projectPath,
     );

--- a/webapp/src/RepoGit.ts
+++ b/webapp/src/RepoGit.ts
@@ -25,15 +25,15 @@ export class RepoGit {
     this.git = new SimpleGitWrapper(spConfig.repoPath);
   }
 
-  static async getRepoGit(config: ServerProjectConfig): Promise<RepoGit> {
-    const key = config.repoPath;
+  static async getRepoGit(spConfig: ServerProjectConfig): Promise<RepoGit> {
+    const key = spConfig.repoPath;
     if (key in RepoGit.repositories) {
       return RepoGit.repositories[key];
     }
     const { promise, resolve, reject } = Promise.withResolvers<RepoGit>();
     RepoGit.repositories[key] = promise;
 
-    const repository = new RepoGit(config);
+    const repository = new RepoGit(spConfig);
     repository.checkoutBaseAndPull().then(() => resolve(repository), reject);
 
     return promise;
@@ -175,10 +175,4 @@ export class RepoGit {
     }
     return paths;
   }
-}
-
-export async function getRepoGit(
-  config: ServerProjectConfig,
-): Promise<RepoGit> {
-  return RepoGit.getRepoGit(config);
 }

--- a/webapp/src/app/api/messages/[projectName]/route.ts
+++ b/webapp/src/app/api/messages/[projectName]/route.ts
@@ -1,6 +1,6 @@
 import MessageAdapterFactory from '@/utils/adapters/MessageAdapterFactory';
+import { RepoGit } from '@/RepoGit';
 import { ServerConfig } from '@/utils/serverConfig';
-import { getRepoGit, RepoGit } from '@/RepoGit';
 import {
   LyraConfigReadingError,
   ProjectNameNotFoundError,
@@ -17,8 +17,8 @@ export async function GET(
     const serverProjectConfig =
       await ServerConfig.getProjectConfig(projectName);
     await RepoGit.cloneIfNotExist(serverProjectConfig);
-    const repo = await getRepoGit(serverProjectConfig);
-    const lyraConfig = await repo.getLyraConfig();
+    const repoGit = await RepoGit.getRepoGit(serverProjectConfig);
+    const lyraConfig = await repoGit.getLyraConfig();
     const projectConfig = lyraConfig.getProjectConfigByPath(
       serverProjectConfig.projectPath,
     );

--- a/webapp/src/app/api/messages/[projectName]/route.ts
+++ b/webapp/src/app/api/messages/[projectName]/route.ts
@@ -1,7 +1,6 @@
-import { LyraConfig } from '@/utils/lyraConfig';
 import MessageAdapterFactory from '@/utils/adapters/MessageAdapterFactory';
-import { RepoGit } from '@/RepoGit';
 import { ServerConfig } from '@/utils/serverConfig';
+import { getRepoGit, RepoGit } from '@/RepoGit';
 import {
   LyraConfigReadingError,
   ProjectNameNotFoundError,
@@ -18,9 +17,8 @@ export async function GET(
     const serverProjectConfig =
       await ServerConfig.getProjectConfig(projectName);
     await RepoGit.cloneIfNotExist(serverProjectConfig);
-    const lyraConfig = await LyraConfig.readFromDir(
-      serverProjectConfig.repoPath,
-    );
+    const repo = await getRepoGit(serverProjectConfig);
+    const lyraConfig = await repo.getLyraConfig();
     const projectConfig = lyraConfig.getProjectConfigByPath(
       serverProjectConfig.projectPath,
     );

--- a/webapp/src/app/api/pull-request/[projectName]/route.ts
+++ b/webapp/src/app/api/pull-request/[projectName]/route.ts
@@ -1,5 +1,5 @@
+import { getRepoGit } from '@/RepoGit';
 import { ProjectNameNotFoundError } from '@/errors';
-import { RepoGit } from '@/RepoGit';
 import { NextRequest, NextResponse } from 'next/server';
 import { ServerConfig, ServerProjectConfig } from '@/utils/serverConfig';
 
@@ -37,7 +37,7 @@ export async function POST(
 
   try {
     syncLock.set(repoPath, true);
-    const repoGit = new RepoGit(serverProjectConfig);
+    const repoGit = await getRepoGit(serverProjectConfig);
     const baseBranch = await repoGit.checkoutBaseAndPull();
     const langFilePaths = await repoGit.saveLanguageFiles(
       serverProjectConfig.projectPath,

--- a/webapp/src/app/api/pull-request/[projectName]/route.ts
+++ b/webapp/src/app/api/pull-request/[projectName]/route.ts
@@ -1,5 +1,5 @@
-import { getRepoGit } from '@/RepoGit';
 import { ProjectNameNotFoundError } from '@/errors';
+import { RepoGit } from '@/RepoGit';
 import { NextRequest, NextResponse } from 'next/server';
 import { ServerConfig, ServerProjectConfig } from '@/utils/serverConfig';
 
@@ -37,7 +37,7 @@ export async function POST(
 
   try {
     syncLock.set(repoPath, true);
-    const repoGit = await getRepoGit(serverProjectConfig);
+    const repoGit = await RepoGit.getRepoGit(serverProjectConfig);
     const baseBranch = await repoGit.checkoutBaseAndPull();
     const langFilePaths = await repoGit.saveLanguageFiles(
       serverProjectConfig.projectPath,

--- a/webapp/src/app/api/translations/[projectName]/[lang]/[msgId]/route.ts
+++ b/webapp/src/app/api/translations/[projectName]/[lang]/[msgId]/route.ts
@@ -1,6 +1,6 @@
 import { Cache } from '@/Cache';
+import { RepoGit } from '@/RepoGit';
 import { ServerConfig } from '@/utils/serverConfig';
-import { getRepoGit, RepoGit } from '@/RepoGit';
 import {
   LanguageNotFound,
   LanguageNotSupported,
@@ -23,11 +23,11 @@ export async function PUT(
   const { lang, msgId, projectName } = context.params;
   const payload = await req.json();
   const { text } = payload;
-  // TODO: include getProjectConfig & readFromDir in a try/catch block and check for error to return a certain 500 error
+  // TODO: include getProjectConfig() and getLyraConfig() in a try/catch block and check for error to return a certain 500 error
   const serverProjectConfig = await ServerConfig.getProjectConfig(projectName);
   await RepoGit.cloneIfNotExist(serverProjectConfig);
-  const repo = await getRepoGit(serverProjectConfig);
-  const lyraConfig = await repo.getLyraConfig();
+  const repoGit = await RepoGit.getRepoGit(serverProjectConfig);
+  const lyraConfig = await repoGit.getLyraConfig();
 
   try {
     const projectConfig = lyraConfig.getProjectConfigByPath(

--- a/webapp/src/app/api/translations/[projectName]/[lang]/[msgId]/route.ts
+++ b/webapp/src/app/api/translations/[projectName]/[lang]/[msgId]/route.ts
@@ -1,7 +1,6 @@
 import { Cache } from '@/Cache';
-import { LyraConfig } from '@/utils/lyraConfig';
-import { RepoGit } from '@/RepoGit';
 import { ServerConfig } from '@/utils/serverConfig';
+import { getRepoGit, RepoGit } from '@/RepoGit';
 import {
   LanguageNotFound,
   LanguageNotSupported,
@@ -27,7 +26,8 @@ export async function PUT(
   // TODO: include getProjectConfig & readFromDir in a try/catch block and check for error to return a certain 500 error
   const serverProjectConfig = await ServerConfig.getProjectConfig(projectName);
   await RepoGit.cloneIfNotExist(serverProjectConfig);
-  const lyraConfig = await LyraConfig.readFromDir(serverProjectConfig.repoPath);
+  const repo = await getRepoGit(serverProjectConfig);
+  const lyraConfig = await repo.getLyraConfig();
 
   try {
     const projectConfig = lyraConfig.getProjectConfigByPath(

--- a/webapp/src/utils/adapters/MessageAdapterFactory.ts
+++ b/webapp/src/utils/adapters/MessageAdapterFactory.ts
@@ -3,11 +3,11 @@ import YamlMessageAdapter from './YamlMessageAdapter';
 import { LyraProjectConfig, MessageKind } from '../lyraConfig';
 
 export default class MessageAdapterFactory {
-  static createAdapter(config: LyraProjectConfig) {
-    if (config.messageKind == MessageKind.TS) {
-      return new TsMessageAdapter(config.absMessagesPath);
+  static createAdapter(lpConfig: LyraProjectConfig) {
+    if (lpConfig.messageKind == MessageKind.TS) {
+      return new TsMessageAdapter(lpConfig.absMessagesPath);
     } else {
-      return new YamlMessageAdapter(config.absMessagesPath);
+      return new YamlMessageAdapter(lpConfig.absMessagesPath);
     }
   }
 }


### PR DESCRIPTION
Move all initializing git pull into RepoGit and make RepoGit shared for each unique local git clone.

As the repository specific configuration file is potentially stale, we need to do this initializing pull before any read of that configuration file. To ensure that, I replace all direct reads with a read through RepoGit. Since the factory always pulls, we know the config will be fresh after a Lyra server start.

Note that the route for creating pull-requests can now theoretically pull twice, if RepoGit was not initialzied first. That is however extremely unlikely as button the create pull requests is on a page that uses RepoGit to load its data. Anyway, I beleive we will resolve this when we implement resyncing from the remotes.