### PR TITLE
Align route param naming convention

### DIFF
--- a/webapp/src/app/api/translations/[projectName]/[languageName]/[messageId]/route.ts
+++ b/webapp/src/app/api/translations/[projectName]/[languageName]/[messageId]/route.ts
@@ -54,6 +54,6 @@ export async function PUT(
   return NextResponse.json({
     languageName,
     messageId,
-    projectName,
+    text,
   });
 }

--- a/webapp/src/app/api/translations/[projectName]/[languageName]/[messageId]/route.ts
+++ b/webapp/src/app/api/translations/[projectName]/[languageName]/[messageId]/route.ts
@@ -14,13 +14,13 @@ export async function PUT(
   req: NextRequest,
   context: {
     params: {
-      lang: string;
-      msgId: string;
+      languageName: string;
+      messageId: string;
       projectName: string;
     };
   },
 ) {
-  const { lang, msgId, projectName } = context.params;
+  const { languageName, messageId, projectName } = context.params;
   const payload = await req.json();
   const { text } = payload;
   // TODO: include getProjectConfig() and getLyraConfig() in a try/catch block and check for error to return a certain 500 error
@@ -33,11 +33,11 @@ export async function PUT(
     const projectConfig = lyraConfig.getProjectConfigByPath(
       serverProjectConfig.projectPath,
     );
-    if (!projectConfig.isLanguageSupported(lang)) {
-      throw new LanguageNotSupported(lang, projectName);
+    if (!projectConfig.isLanguageSupported(languageName)) {
+      throw new LanguageNotSupported(languageName, projectName);
     }
     const projectStore = await Cache.getProjectStore(projectConfig);
-    await projectStore.updateTranslation(lang, msgId, text);
+    await projectStore.updateTranslation(languageName, messageId, text);
   } catch (e) {
     if (
       e instanceof LanguageNotFound ||
@@ -52,8 +52,8 @@ export async function PUT(
   }
 
   return NextResponse.json({
-    lang,
-    msgId,
-    text,
+    languageName,
+    messageId,
+    projectName,
   });
 }

--- a/webapp/src/app/api/translations/[projectName]/[languageName]/route.ts
+++ b/webapp/src/app/api/translations/[projectName]/[languageName]/route.ts
@@ -8,13 +8,13 @@ import { NextRequest, NextResponse } from 'next/server';
 
 export async function GET(
   req: NextRequest, // keep this here even if unused
-  context: { params: { lang: string; projectName: string } },
+  context: { params: { languageName: string; projectName: string } },
 ) {
-  const { projectName, lang } = context.params;
+  const { projectName, languageName } = context.params;
   try {
-    const translations = await Cache.getLanguage(projectName, lang);
+    const translations = await Cache.getLanguage(projectName, languageName);
     return NextResponse.json({
-      lang,
+      languageName,
       translations,
     });
   } catch (e) {

--- a/webapp/src/app/projects/[projectName]/[languageName]/page.tsx
+++ b/webapp/src/app/projects/[projectName]/[languageName]/page.tsx
@@ -7,7 +7,7 @@ import { Box, Button, Input, Link, Typography } from '@mui/joy';
 import { useEffect, useMemo, useState } from 'react';
 
 export default function Home(context: {
-  params: { lang: string; projectName: string };
+  params: { languageName: string; projectName: string };
 }) {
   const [filterText, setFilterText] = useState('');
   const [messages, setMessages] = useState<MessageData[]>([]);
@@ -51,7 +51,7 @@ export default function Home(context: {
   }, [sortedMessages, filterText]);
 
   const {
-    params: { lang, projectName },
+    params: { languageName, projectName },
   } = context;
 
   useEffect(() => {
@@ -83,7 +83,9 @@ export default function Home(context: {
 
   useEffect(() => {
     async function loadTranslations() {
-      const res = await fetch(`/api/translations/${projectName}/${lang}`);
+      const res = await fetch(
+        `/api/translations/${projectName}/${languageName}`,
+      );
 
       try {
         const payload = await res.json();
@@ -180,7 +182,7 @@ export default function Home(context: {
               message={msg}
               onSave={async (text) => {
                 await fetch(
-                  `/api/translations/${projectName}/${lang}/${msg.id}`,
+                  `/api/translations/${projectName}/${languageName}/${msg.id}`,
                   {
                     body: JSON.stringify({
                       text,


### PR DESCRIPTION
Our route param names are currently a bit of a mish-mash of long-form compound names like `projectName` and highly abbreviated shorthands like `lang`. Here's how it'd look if either style were consistently applied across all routes.

| Long-form compound names | Highly abbreviated shorthand |
|-|-|
| `projectName` | `proj` |
| `languageName` | `lang` |
| `messageId` | `msgId` |

I think it's always easiest to establish a consistent pattern in this kind of stuff in the early days before the surface area grows to a point where it's an expensive thing to tidy up. Based on the above table my guess is that the long-form names are the ones we'd rather align on so this PR switches everything over to them.

In some cases this causes JSON response properties to change names in API responses. I think that's fine, partly because nothing's depending on them yet, and also partly because I think [server actions](https://nextjs.org/docs/app/building-your-application/data-fetching/server-actions-and-mutations) are going to replace those API endpoints soon enough anyway.