### PR TITLE
Remove projects page

### DIFF
--- a/webapp/README.md
+++ b/webapp/README.md
@@ -71,11 +71,12 @@ projects:
 
 Start the server with `yarn dev` in `webapp`.
 
-Open `http://localhost:3000/projects` to view the configured projects.
+Open the URL provided in the terminal to view projects.
 
-For a project `example-unique-name` and a language `yy`,
-open `http://localhost:3000/projects/example-unique-name/yy`
-to open the translation user interface.
+Click on projects to view project pages
+or click on languages to view translation pages.
+
+Open `http://localhost:3000/projects` to view project configuration.
 
 ## Dependencies
 

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -76,8 +76,6 @@ Open the URL provided in the terminal to view projects.
 Click on projects to view project pages
 or click on languages to view translation pages.
 
-Open `http://localhost:3000/projects` to view project configuration.
-
 ## Dependencies
 
 Lyra runs on Node and likely uses its HTTP-server to serve requests

--- a/webapp/src/app/api/projects/route.ts
+++ b/webapp/src/app/api/projects/route.ts
@@ -1,3 +1,0 @@
-export async function GET() {
-  return new Response();
-}

--- a/webapp/src/app/api/projects/route.ts
+++ b/webapp/src/app/api/projects/route.ts
@@ -1,5 +1,3 @@
-import { NextResponse } from 'next/server';
-
 export async function GET() {
-  return NextResponse.json({});
+  return new Response();
 }

--- a/webapp/src/app/api/projects/route.ts
+++ b/webapp/src/app/api/projects/route.ts
@@ -7,9 +7,7 @@ export async function GET() {
   try {
     const serverConfig = await ServerConfig.read();
     return NextResponse.json<ProjectsResponse>({
-      projects: serverConfig.projects.map<ProjectItem>((project) => ({
-        name: project.name,
-      })),
+      projects: serverConfig.projects.map<ProjectItem>(() => ({})),
     });
   } catch (e) {
     if (e instanceof ServerConfigReadingError) {

--- a/webapp/src/app/api/projects/route.ts
+++ b/webapp/src/app/api/projects/route.ts
@@ -9,7 +9,6 @@ export async function GET() {
     return NextResponse.json<ProjectsResponse>({
       projects: serverConfig.projects.map<ProjectItem>((project) => ({
         name: project.name,
-        owner: project.owner,
       })),
     });
   } catch (e) {

--- a/webapp/src/app/api/projects/route.ts
+++ b/webapp/src/app/api/projects/route.ts
@@ -1,18 +1,5 @@
 import { NextResponse } from 'next/server';
-import { ServerConfig } from '@/utils/serverConfig';
-import { ServerConfigReadingError } from '@/errors';
-import { type ProjectItem, type ProjectsResponse } from '@/types';
 
 export async function GET() {
-  try {
-    const serverConfig = await ServerConfig.read();
-    return NextResponse.json<ProjectsResponse>({
-      projects: serverConfig.projects.map<ProjectItem>(() => ({})),
-    });
-  } catch (e) {
-    if (e instanceof ServerConfigReadingError) {
-      return NextResponse.json({ message: e.message }, { status: 500 });
-    }
-    throw e;
-  }
+  return NextResponse.json({});
 }

--- a/webapp/src/app/api/projects/route.ts
+++ b/webapp/src/app/api/projects/route.ts
@@ -10,7 +10,6 @@ export async function GET() {
       projects: serverConfig.projects.map<ProjectItem>((project) => ({
         name: project.name,
         owner: project.owner,
-        projectPath: project.projectPath,
         repo: project.repo,
       })),
     });

--- a/webapp/src/app/api/projects/route.ts
+++ b/webapp/src/app/api/projects/route.ts
@@ -10,7 +10,6 @@ export async function GET() {
       projects: serverConfig.projects.map<ProjectItem>((project) => ({
         name: project.name,
         owner: project.owner,
-        repo: project.repo,
       })),
     });
   } catch (e) {

--- a/webapp/src/app/projects/page.tsx
+++ b/webapp/src/app/projects/page.tsx
@@ -1,7 +1,0 @@
-export default function Home() {
-  return (
-    <main>
-      <h1>Projects</h1>
-    </main>
-  );
-}

--- a/webapp/src/app/projects/page.tsx
+++ b/webapp/src/app/projects/page.tsx
@@ -5,8 +5,7 @@ import { useEffect } from 'react';
 export default function Home() {
   useEffect(() => {
     async function loadProjects() {
-      const res = await fetch('/api/projects');
-      await res.json();
+      await fetch('/api/projects');
     }
 
     loadProjects();

--- a/webapp/src/app/projects/page.tsx
+++ b/webapp/src/app/projects/page.tsx
@@ -25,7 +25,6 @@ export default function Home() {
         {projectsResponse.projects.map((project) => (
           <li key={project.name} className="project-item">
             <h2>{project.name}</h2>
-            <p>owner: {project.owner}</p>
           </li>
         ))}
       </ul>

--- a/webapp/src/app/projects/page.tsx
+++ b/webapp/src/app/projects/page.tsx
@@ -26,7 +26,6 @@ export default function Home() {
           <li key={project.name} className="project-item">
             <h2>{project.name}</h2>
             <p>owner: {project.owner}</p>
-            <p>repo: {project.repo}</p>
           </li>
         ))}
       </ul>

--- a/webapp/src/app/projects/page.tsx
+++ b/webapp/src/app/projects/page.tsx
@@ -4,7 +4,7 @@ import { type ProjectsResponse } from '@/types';
 import { useEffect, useState } from 'react';
 
 export default function Home() {
-  const [projectsResponse, setProjectsResponse] = useState<ProjectsResponse>({
+  const [, setProjectsResponse] = useState<ProjectsResponse>({
     projects: [],
   });
 
@@ -21,11 +21,6 @@ export default function Home() {
   return (
     <main>
       <h1>Projects</h1>
-      <ul>
-        {projectsResponse.projects.map((project) => (
-          <li key={project.name} className="project-item" />
-        ))}
-      </ul>
     </main>
   );
 }

--- a/webapp/src/app/projects/page.tsx
+++ b/webapp/src/app/projects/page.tsx
@@ -23,9 +23,7 @@ export default function Home() {
       <h1>Projects</h1>
       <ul>
         {projectsResponse.projects.map((project) => (
-          <li key={project.name} className="project-item">
-            <h2>{project.name}</h2>
-          </li>
+          <li key={project.name} className="project-item" />
         ))}
       </ul>
     </main>

--- a/webapp/src/app/projects/page.tsx
+++ b/webapp/src/app/projects/page.tsx
@@ -1,16 +1,4 @@
-'use client';
-
-import { useEffect } from 'react';
-
 export default function Home() {
-  useEffect(() => {
-    async function loadProjects() {
-      await fetch('/api/projects');
-    }
-
-    loadProjects();
-  }, []);
-
   return (
     <main>
       <h1>Projects</h1>

--- a/webapp/src/app/projects/page.tsx
+++ b/webapp/src/app/projects/page.tsx
@@ -27,7 +27,6 @@ export default function Home() {
             <h2>{project.name}</h2>
             <p>owner: {project.owner}</p>
             <p>repo: {project.repo}</p>
-            <p>Project path: {project.projectPath}</p>
           </li>
         ))}
       </ul>

--- a/webapp/src/app/projects/page.tsx
+++ b/webapp/src/app/projects/page.tsx
@@ -1,18 +1,12 @@
 'use client';
 
-import { type ProjectsResponse } from '@/types';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 
 export default function Home() {
-  const [, setProjectsResponse] = useState<ProjectsResponse>({
-    projects: [],
-  });
-
   useEffect(() => {
     async function loadProjects() {
       const res = await fetch('/api/projects');
-      const payload = await res.json();
-      setProjectsResponse(payload);
+      await res.json();
     }
 
     loadProjects();

--- a/webapp/src/types.ts
+++ b/webapp/src/types.ts
@@ -7,9 +7,7 @@ declare global {
   var store: Store;
 }
 
-export type ProjectItem = {
-  name: string;
-};
+export type ProjectItem = Record<string, never>;
 
 export type ProjectsResponse = {
   projects: ProjectItem[];

--- a/webapp/src/types.ts
+++ b/webapp/src/types.ts
@@ -9,7 +9,6 @@ declare global {
 
 export type ProjectItem = {
   name: string;
-  owner: string;
 };
 
 export type ProjectsResponse = {

--- a/webapp/src/types.ts
+++ b/webapp/src/types.ts
@@ -6,9 +6,3 @@ declare global {
   // eslint-disable-next-line
   var store: Store;
 }
-
-export type ProjectItem = Record<string, never>;
-
-export type ProjectsResponse = {
-  projects: ProjectItem[];
-};

--- a/webapp/src/types.ts
+++ b/webapp/src/types.ts
@@ -10,7 +10,6 @@ declare global {
 export type ProjectItem = {
   name: string;
   owner: string;
-  projectPath: string;
   repo: string;
 };
 

--- a/webapp/src/types.ts
+++ b/webapp/src/types.ts
@@ -10,7 +10,6 @@ declare global {
 export type ProjectItem = {
   name: string;
   owner: string;
-  repo: string;
 };
 
 export type ProjectsResponse = {


### PR DESCRIPTION
Now that we have the pretty home page, there is no need for the old projects page except maybe as a base for a future administrator UI. An admin UI is pretty far away though and in the meantime, it is useful to reduce complexity as we expect some large changes in #25 