### PR TITLE
Refactor project fetching into a helper function shared with the API

### DIFF
--- a/webapp/src/app/api/projects/route.ts
+++ b/webapp/src/app/api/projects/route.ts
@@ -1,19 +1,11 @@
+import getProjects from '@/lib/getProjects';
 import { NextResponse } from 'next/server';
-import { ServerConfig } from '@/utils/serverConfig';
 import { ServerConfigReadingError } from '@/errors';
-import { type ProjectItem, type ProjectsResponse } from '@/types';
 
 export async function GET() {
   try {
-    const serverConfig = await ServerConfig.read();
-    return NextResponse.json<ProjectsResponse>({
-      projects: serverConfig.projects.map<ProjectItem>((project) => ({
-        name: project.name,
-        owner: project.owner,
-        projectPath: project.projectPath,
-        repo: project.repo,
-      })),
-    });
+    const projects = await getProjects();
+    return NextResponse.json(projects);
   } catch (e) {
     if (e instanceof ServerConfigReadingError) {
       return NextResponse.json({ message: e.message }, { status: 500 });

--- a/webapp/src/app/projects/page.tsx
+++ b/webapp/src/app/projects/page.tsx
@@ -4,15 +4,13 @@ import { type ProjectsResponse } from '@/types';
 import { useEffect, useState } from 'react';
 
 export default function Home() {
-  const [projectsResponse, setProjectsResponse] = useState<ProjectsResponse>({
-    projects: [],
-  });
+  const [projects, setProjects] = useState<ProjectsResponse>([]);
 
   useEffect(() => {
     async function loadProjects() {
       const res = await fetch('/api/projects');
       const payload = await res.json();
-      setProjectsResponse(payload);
+      setProjects(payload);
     }
 
     loadProjects();
@@ -22,12 +20,9 @@ export default function Home() {
     <main>
       <h1>Projects</h1>
       <ul>
-        {projectsResponse.projects.map((project) => (
+        {projects.map((project) => (
           <li key={project.name} className="project-item">
             <h2>{project.name}</h2>
-            <p>owner: {project.owner}</p>
-            <p>repo: {project.repo}</p>
-            <p>Project path: {project.projectPath}</p>
           </li>
         ))}
       </ul>

--- a/webapp/src/lib/getProjects.ts
+++ b/webapp/src/lib/getProjects.ts
@@ -1,0 +1,44 @@
+import { Cache } from '@/Cache';
+import MessageAdapterFactory from '@/utils/adapters/MessageAdapterFactory';
+import { ProjectCardProps } from '@/components/ProjectCard';
+import { ProjectsResponse } from '@/types';
+import { RepoGit } from '@/RepoGit';
+import { ServerConfig } from '@/utils/serverConfig';
+
+export default async function getProjects(): Promise<ProjectsResponse> {
+  const serverConfig = await ServerConfig.read();
+  const projects = await Promise.all(
+    serverConfig.projects.map<Promise<ProjectCardProps>>(async (project) => {
+      await RepoGit.cloneIfNotExist(project);
+      const repoGit = await RepoGit.getRepoGit(project);
+      const lyraConfig = await repoGit.getLyraConfig();
+      const projectConfig = lyraConfig.getProjectConfigByPath(
+        project.projectPath,
+      );
+      const msgAdapter = MessageAdapterFactory.createAdapter(projectConfig);
+      const messages = await msgAdapter.getMessages();
+      const store = await Cache.getProjectStore(projectConfig);
+      const languages = await Promise.all(
+        projectConfig.languages.map(async (lang) => {
+          const translations = await store.getTranslations(lang);
+          return {
+            href: `/projects/${project.name}/${lang}`,
+            language: lang,
+            progress: translations
+              ? (Object.keys(translations).length / messages.length) * 100
+              : 0,
+          };
+        }),
+      );
+
+      return {
+        href: `/projects/${project.name}`,
+        languages,
+        messageCount: messages.length,
+        name: project.name,
+      };
+    }),
+  );
+
+  return projects;
+}

--- a/webapp/src/types.ts
+++ b/webapp/src/types.ts
@@ -15,5 +15,12 @@ export type ProjectItem = {
 };
 
 export type ProjectsResponse = {
-  projects: ProjectItem[];
-};
+  href: string;
+  languages: {
+    href: string;
+    language: string;
+    progress: number;
+  }[];
+  messageCount: number;
+  name: string;
+}[];


### PR DESCRIPTION
This is a follow-up to the Slack conversation about data fetching, where we discussed the trade-offs of handling data fetching directly in server components, handling it client-side via REST API calls from the browser, and various middle-ground options between those two extremes.

Currently we've reached a point where we'd like to keep having a REST API. Although it's true that Next.js has added a lot of features that reduce the immediate, urgent _need_ for a REST API, such as server components and server actions, we feel we'd like to build one anyway because of the interoperability benefits they bring later, when integrating with other systems.

Where we arrived at was that it'd be nice to take advantage of Next's great server rendering capabilities, but to have the server components delegate the data fetching work to the REST API endpoints. This pull request takes a step in that direction by extracting the home page's data fetching code into a helper function and then updating the REST API's `/projects` endpoint to use that helper function.

This aligns the REST API endpoint's response schema with the actual needs of the app feature that uses it, and puts us within touching distance of the approach discussed in Slack.

| UI | API |
|-|-|
| ![Screenshot 2024-06-11 at 20 12 27](https://github.com/zetkin/lyra/assets/566159/5e08852b-4a53-438b-8a04-c116c058d129) | ![Screenshot 2024-06-11 at 20 12 12](https://github.com/zetkin/lyra/assets/566159/8d9cd9a3-1d9c-47bd-8cce-577d26c5ac8e) |

I haven't gone 100% of the way on this. The home page's server component is still fetching its own data directly, bypassing the REST API. There are two reasons for this.

1. It wasn't immediately clear to me what was the correct way to formulate a `fetch()` call from a Next.js application server to _itself_, and I didn't easily find examples to learn from when searching.
2. I think it's actually worth pausing in this intermediate state here and asking ourselves if we'll be improving something in a way that matters by spending time replacing a call to `await getProjects()` here with a call to `await fetch()`, as compared to prioritising forward progress on app functionality that translators can use to build Zetkin itself more efficiently.