### PR TITLE
Add pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,2 @@
+#!/bin/sh
+yarn lint:formatting && yarn lint:eslint


### PR DESCRIPTION
Almost every time I push I end up with a red build and have to push again cos I missed a lint error. I'm used to the [`.githooks/pre-commit`](https://github.com/zetkin/app.zetkin.org/blob/main/.githooks/pre-commit) config that the other repo has. Could we just have that here?