### PR TITLE
ESLint .prettierrc.json

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,6 +10,13 @@ module.exports = {
   extends: ['eslint:recommended', 'next', 'prettier'],
   settings: { react: { version: 'detect' } },
   overrides: [
+    {
+      files: ['.prettierrc.json'],
+
+      // default parser esprima does not support json
+      parser: '@typescript-eslint/parser',
+    },
+
     // This configuration will apply only to TypeScript files
     {
       files: ['**/*.ts', '**/*.tsx', 'src/**/*.js'],


### PR DESCRIPTION
In e27f9cc5464ccc0a7c8a7eabe2c29d1869515f83 we copied ESLint configuration from app.zetkin.org which specifically activates linting for .prettierrc.js

In Lyra, we use .prettierrc.json instead but json files are not linted by default, or by any extension we use.

See https://eslint.org/docs/v8.x/use/configure/configuration-files#specifying-target-files-to-lint