### PR TITLE
Replace sort-imports with import/order eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -37,6 +37,13 @@ module.exports = {
           },
         ],
         curly: 'error',
+        'import/order': [
+          'error',
+          {
+            groups: [['external', 'builtin']],
+            'newlines-between': 'always',
+          },
+        ],
         'jsx-a11y/anchor-is-valid': 'off',
         'no-console': 'error',
         'no-switch-statements/no-switch': 'error',
@@ -76,14 +83,6 @@ module.exports = {
           {
             component: true,
             html: true,
-          },
-        ],
-        'sort-imports': [
-          'error',
-          {
-            ignoreCase: true,
-            allowSeparatedGroups: true,
-            memberSyntaxSortOrder: ['none', 'all', 'single', 'multiple'],
           },
         ],
         'sort-keys': 'error',

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "eslint": "^7.15.0",
     "eslint-config-next": "13.5.6",
     "eslint-config-prettier": "^8.3.0",
+    "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-next": "^0.0.0",
     "eslint-plugin-no-switch-statements": "^1.0.0",

--- a/webapp/src/RepoGit.ts
+++ b/webapp/src/RepoGit.ts
@@ -1,14 +1,15 @@
-import { Cache } from '@/Cache';
 import fs from 'fs';
 import fsp from 'fs/promises';
+import { Octokit } from '@octokit/rest';
+import path from 'path';
+import { stringify } from 'yaml';
+
+import { Cache } from '@/Cache';
 import { IGit } from '@/utils/git/IGit';
 import { LyraConfig } from '@/utils/lyraConfig';
-import { Octokit } from '@octokit/rest';
 import packageJson from '../package.json';
-import path from 'path';
 import { ServerProjectConfig } from '@/utils/serverConfig';
 import { SimpleGitWrapper } from '@/utils/git/SimpleGitWrapper';
-import { stringify } from 'yaml';
 import { unflattenObject } from '@/utils/unflattenObject';
 import { debug, info, warn } from '@/utils/log';
 import { WriteLanguageFileError, WriteLanguageFileErrors } from '@/errors';

--- a/webapp/src/app/api/messages/[projectName]/route.ts
+++ b/webapp/src/app/api/messages/[projectName]/route.ts
@@ -1,3 +1,5 @@
+import { NextRequest, NextResponse } from 'next/server';
+
 import MessageAdapterFactory from '@/utils/adapters/MessageAdapterFactory';
 import { RepoGit } from '@/RepoGit';
 import { ServerConfig } from '@/utils/serverConfig';
@@ -6,7 +8,6 @@ import {
   ProjectNameNotFoundError,
   ProjectPathNotFoundError,
 } from '@/errors';
-import { NextRequest, NextResponse } from 'next/server';
 
 export async function GET(
   req: NextRequest,

--- a/webapp/src/app/api/projects/route.ts
+++ b/webapp/src/app/api/projects/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+
 import { ServerConfig } from '@/utils/serverConfig';
 import { ServerConfigReadingError } from '@/errors';
 import { type ProjectItem, type ProjectsResponse } from '@/types';

--- a/webapp/src/app/api/pull-request/[projectName]/route.ts
+++ b/webapp/src/app/api/pull-request/[projectName]/route.ts
@@ -1,6 +1,7 @@
+import { NextRequest, NextResponse } from 'next/server';
+
 import { ProjectNameNotFoundError } from '@/errors';
 import { RepoGit } from '@/RepoGit';
-import { NextRequest, NextResponse } from 'next/server';
 import { ServerConfig, ServerProjectConfig } from '@/utils/serverConfig';
 
 /** used to prevent multiple requests from running at the same time */

--- a/webapp/src/app/api/translations/[projectName]/[languageName]/[messageId]/route.ts
+++ b/webapp/src/app/api/translations/[projectName]/[languageName]/[messageId]/route.ts
@@ -1,3 +1,5 @@
+import { NextRequest, NextResponse } from 'next/server';
+
 import { Cache } from '@/Cache';
 import { RepoGit } from '@/RepoGit';
 import { ServerConfig } from '@/utils/serverConfig';
@@ -8,7 +10,6 @@ import {
   ProjectNameNotFoundError,
   ProjectPathNotFoundError,
 } from '@/errors';
-import { NextRequest, NextResponse } from 'next/server';
 
 export async function PUT(
   req: NextRequest,

--- a/webapp/src/app/api/translations/[projectName]/[languageName]/route.ts
+++ b/webapp/src/app/api/translations/[projectName]/[languageName]/route.ts
@@ -1,10 +1,11 @@
+import { NextRequest, NextResponse } from 'next/server';
+
 import { Cache } from '@/Cache';
 import {
   LanguageNotFound,
   LanguageNotSupported,
   ProjectNameNotFoundError,
 } from '@/errors';
-import { NextRequest, NextResponse } from 'next/server';
 
 export async function GET(
   req: NextRequest, // keep this here even if unused

--- a/webapp/src/app/projects/[projectName]/[languageName]/page.tsx
+++ b/webapp/src/app/projects/[projectName]/[languageName]/page.tsx
@@ -1,10 +1,11 @@
 'use client';
 
+import { Box, Button, Input, Link, Typography } from '@mui/joy';
+import { useEffect, useMemo, useState } from 'react';
+
 import { type MessageData } from '@/utils/adapters';
 import MessageForm from '@/components/MessageForm';
 import { SafeRecord } from '@/utils/types';
-import { Box, Button, Input, Link, Typography } from '@mui/joy';
-import { useEffect, useMemo, useState } from 'react';
 
 export default function Home(context: {
   params: { languageName: string; projectName: string };

--- a/webapp/src/app/projects/[projectName]/page.tsx
+++ b/webapp/src/app/projects/[projectName]/page.tsx
@@ -1,7 +1,8 @@
-import { Cache } from '@/Cache';
-import MessageAdapterFactory from '@/utils/adapters/MessageAdapterFactory';
 import { NextPage } from 'next';
 import { notFound } from 'next/navigation';
+
+import { Cache } from '@/Cache';
+import MessageAdapterFactory from '@/utils/adapters/MessageAdapterFactory';
 import ProjectDashboard from '@/components/ProjectDashboard';
 import { RepoGit } from '@/RepoGit';
 import { ServerConfig } from '@/utils/serverConfig';

--- a/webapp/src/app/projects/page.tsx
+++ b/webapp/src/app/projects/page.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { type ProjectsResponse } from '@/types';
 import { useEffect, useState } from 'react';
+
+import { type ProjectsResponse } from '@/types';
 
 export default function Home() {
   const [projectsResponse, setProjectsResponse] = useState<ProjectsResponse>({

--- a/webapp/src/components/HomeDashboard.tsx
+++ b/webapp/src/components/HomeDashboard.tsx
@@ -1,6 +1,7 @@
-import { CardGrid } from '@/components/CardGrid';
 import { FC } from 'react';
 import { Box, Typography } from '@mui/joy';
+
+import { CardGrid } from '@/components/CardGrid';
 import ProjectCard, { ProjectCardProps } from '@/components/ProjectCard';
 
 type HomeDashboardProps = {

--- a/webapp/src/components/MessageForm.tsx
+++ b/webapp/src/components/MessageForm.tsx
@@ -1,4 +1,3 @@
-import { type MessageData } from '@/utils/adapters';
 import {
   Box,
   Button,
@@ -9,6 +8,8 @@ import {
   Typography,
 } from '@mui/joy';
 import { FC, useEffect, useState } from 'react';
+
+import { type MessageData } from '@/utils/adapters';
 
 type Props = {
   message: MessageData;

--- a/webapp/src/components/ProjectDashboard.tsx
+++ b/webapp/src/components/ProjectDashboard.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { CardGrid } from '@/components/CardGrid';
 import { FC } from 'react';
 import Link from 'next/link';
 import { Box, Typography, useTheme } from '@mui/joy';
+
+import { CardGrid } from '@/components/CardGrid';
 import LanguageCard, { LanguageCardProps } from '@/components/LanguageCard';
 
 type ProjectDashboardProps = {

--- a/webapp/src/store/ProjectStore.spec.ts
+++ b/webapp/src/store/ProjectStore.spec.ts
@@ -1,5 +1,6 @@
-import { ProjectStore } from './ProjectStore';
 import { describe, expect, it } from '@jest/globals';
+
+import { ProjectStore } from './ProjectStore';
 import { LanguageNotFound, MessageNotFound } from '@/errors';
 
 describe('ProjectStore', () => {

--- a/webapp/src/store/Store.spec.ts
+++ b/webapp/src/store/Store.spec.ts
@@ -1,6 +1,7 @@
+import { describe, expect, it } from '@jest/globals';
+
 import { ProjectStore } from '@/store/ProjectStore';
 import { Store } from './Store';
-import { describe, expect, it } from '@jest/globals';
 
 describe('Store', () => {
   describe('getProjectStore()', () => {

--- a/webapp/src/utils/adapters/TsMessageAdapter.spec.ts
+++ b/webapp/src/utils/adapters/TsMessageAdapter.spec.ts
@@ -1,7 +1,9 @@
-import { type MessageData } from '.';
 import mock from 'mock-fs';
-import TsMessageAdapter from './TsMessageAdapter';
 import { afterEach, describe, expect, it } from '@jest/globals';
+
+import { type MessageData } from '.';
+import TsMessageAdapter from './TsMessageAdapter';
+
 
 describe('TsMessageAdapter', () => {
   afterEach(() => {

--- a/webapp/src/utils/adapters/TsMessageAdapter.spec.ts
+++ b/webapp/src/utils/adapters/TsMessageAdapter.spec.ts
@@ -4,7 +4,6 @@ import { afterEach, describe, expect, it } from '@jest/globals';
 import { type MessageData } from '.';
 import TsMessageAdapter from './TsMessageAdapter';
 
-
 describe('TsMessageAdapter', () => {
   afterEach(() => {
     mock.restore();

--- a/webapp/src/utils/adapters/TsMessageAdapter.ts
+++ b/webapp/src/utils/adapters/TsMessageAdapter.ts
@@ -1,5 +1,6 @@
 import fs from 'fs/promises';
 import path from 'path';
+
 import readTypedMessages from '../readTypedMessages';
 import { IMessageAdapter, type MessageData } from '.';
 

--- a/webapp/src/utils/adapters/YamlMessageAdapter.spec.ts
+++ b/webapp/src/utils/adapters/YamlMessageAdapter.spec.ts
@@ -4,7 +4,6 @@ import { afterEach, describe, expect, it } from '@jest/globals';
 import { type MessageData } from '.';
 import YamlMessageAdapter from './YamlMessageAdapter';
 
-
 describe('YamlMessageAdapter', () => {
   describe('getMessages()', () => {
     afterEach(() => {

--- a/webapp/src/utils/adapters/YamlMessageAdapter.spec.ts
+++ b/webapp/src/utils/adapters/YamlMessageAdapter.spec.ts
@@ -1,7 +1,9 @@
-import { type MessageData } from '.';
 import mock from 'mock-fs';
-import YamlMessageAdapter from './YamlMessageAdapter';
 import { afterEach, describe, expect, it } from '@jest/globals';
+
+import { type MessageData } from '.';
+import YamlMessageAdapter from './YamlMessageAdapter';
+
 
 describe('YamlMessageAdapter', () => {
   describe('getMessages()', () => {

--- a/webapp/src/utils/adapters/YamlMessageAdapter.ts
+++ b/webapp/src/utils/adapters/YamlMessageAdapter.ts
@@ -1,7 +1,8 @@
-import flattenObject from '../flattenObject';
 import fs from 'fs/promises';
 import { parse } from 'yaml';
 import path from 'path';
+
+import flattenObject from '../flattenObject';
 import { IMessageAdapter, type MessageData } from '.';
 
 export default class YamlMessageAdapter implements IMessageAdapter {

--- a/webapp/src/utils/adapters/YamlTranslationAdapter.spec.ts
+++ b/webapp/src/utils/adapters/YamlTranslationAdapter.spec.ts
@@ -1,6 +1,7 @@
 import mock from 'mock-fs';
-import YamlTranslationAdapter from './YamlTranslationAdapter';
 import { afterEach, describe, expect, it } from '@jest/globals';
+
+import YamlTranslationAdapter from './YamlTranslationAdapter';
 
 describe('YamlTranslationAdapter', () => {
   describe('getTranslations()', () => {

--- a/webapp/src/utils/adapters/YamlTranslationAdapter.ts
+++ b/webapp/src/utils/adapters/YamlTranslationAdapter.ts
@@ -1,7 +1,8 @@
-import flattenObject from '../flattenObject';
 import fs from 'fs/promises';
 import { parse } from 'yaml';
 import path from 'path';
+
+import flattenObject from '../flattenObject';
 import { ITranslationAdapter, type TranslationMap } from '.';
 
 export default class YamlTranslationAdapter implements ITranslationAdapter {

--- a/webapp/src/utils/flattenObject.spec.ts
+++ b/webapp/src/utils/flattenObject.spec.ts
@@ -1,5 +1,6 @@
-import flattenObject from './flattenObject';
 import { describe, expect, it } from '@jest/globals';
+
+import flattenObject from './flattenObject';
 
 describe('flattenObject()', () => {
   it('returns empty object for empty obj', () => {

--- a/webapp/src/utils/git/SimpleGitWrapper.ts
+++ b/webapp/src/utils/git/SimpleGitWrapper.ts
@@ -1,5 +1,6 @@
-import { IGit } from './IGit';
 import { simpleGit, SimpleGit, SimpleGitOptions } from 'simple-git';
+
+import { IGit } from './IGit';
 
 export class SimpleGitWrapper implements IGit {
   private readonly git: SimpleGit;

--- a/webapp/src/utils/lyraConfig.spec.ts
+++ b/webapp/src/utils/lyraConfig.spec.ts
@@ -1,5 +1,6 @@
 import mock from 'mock-fs';
 import { afterEach, describe, expect, it } from '@jest/globals';
+
 import { LyraConfig, MessageKind } from './lyraConfig';
 import { LyraConfigReadingError, ProjectPathNotFoundError } from '@/errors';
 

--- a/webapp/src/utils/lyraConfig.ts
+++ b/webapp/src/utils/lyraConfig.ts
@@ -2,6 +2,7 @@ import fs from 'fs/promises';
 import { parse } from 'yaml';
 import path from 'path';
 import { z } from 'zod';
+
 import { LyraConfigReadingError, ProjectPathNotFoundError } from '@/errors';
 
 export enum MessageKind {

--- a/webapp/src/utils/readTypedMessages.ts
+++ b/webapp/src/utils/readTypedMessages.ts
@@ -1,5 +1,6 @@
-import { type MessageData } from './adapters';
 import ts from 'typescript';
+
+import { type MessageData } from './adapters';
 
 export default function readTypedMessages(fileName: string): MessageData[] {
   const host = ts.createIncrementalCompilerHost(

--- a/webapp/src/utils/serverConfig.spec.ts
+++ b/webapp/src/utils/serverConfig.spec.ts
@@ -1,6 +1,7 @@
 import mock from 'mock-fs';
-import { ServerConfig } from './serverConfig';
 import { afterEach, describe, expect, it } from '@jest/globals';
+
+import { ServerConfig } from './serverConfig';
 import { ProjectNameNotFoundError, ServerConfigReadingError } from '@/errors';
 
 describe('ServerConfig', () => {

--- a/webapp/src/utils/serverConfig.ts
+++ b/webapp/src/utils/serverConfig.ts
@@ -2,6 +2,7 @@ import fs from 'fs/promises';
 import { parse } from 'yaml';
 import path from 'path';
 import { z } from 'zod';
+
 import { ProjectNameNotFoundError, ServerConfigReadingError } from '@/errors';
 
 const serverConfigSchema = z.object({

--- a/webapp/src/utils/unflattenObject.spec.ts
+++ b/webapp/src/utils/unflattenObject.spec.ts
@@ -1,5 +1,6 @@
-import { unflattenObject } from './unflattenObject';
 import { describe, expect, it } from '@jest/globals';
+
+import { unflattenObject } from './unflattenObject';
 
 describe('unflattenObject()', () => {
   it('returns empty object for empty obj', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2330,7 +2330,7 @@ eslint-module-utils@^2.8.0:
   dependencies:
     debug "^3.2.7"
 
-eslint-plugin-import@^2.28.1:
+eslint-plugin-import@^2.28.1, eslint-plugin-import@^2.29.1:
   version "2.29.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.29.1.tgz#d45b37b5ef5901d639c15270d74d46d161150643"
   integrity sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==


### PR DESCRIPTION
See https://github.com/zetkin/app.zetkin.org/pull/2065

Note that alphabetize defaults to ignore.

Documentation is at: https://github.com/import-js/eslint-plugin-import/blob/v2.29.1/docs/rules/order.md