### PR TITLE
Disable git symlinks

### DIFF
--- a/webapp/src/utils/git/SimpleGitWrapper.ts
+++ b/webapp/src/utils/git/SimpleGitWrapper.ts
@@ -9,6 +9,11 @@ export class SimpleGitWrapper implements IGit {
     const options: Partial<SimpleGitOptions> = {
       baseDir: repoPath,
       binary: 'git',
+
+      /* We disable symlinks to reduce risk of access to files
+         outside of the local repository */
+      config: ['core.symlinks=false'],
+
       maxConcurrentProcesses: 1,
       trimmed: false,
     };


### PR DESCRIPTION
Symbolic links could possible be used to escape the configured local repository path.

See #34 