### PR TITLE
Validate languages from lyra.yml

### DIFF
--- a/webapp/src/utils/git/SimpleGitWrapper.ts
+++ b/webapp/src/utils/git/SimpleGitWrapper.ts
@@ -10,8 +10,10 @@ export class SimpleGitWrapper implements IGit {
       baseDir: repoPath,
       binary: 'git',
 
-      /* We disable symlinks to reduce risk of access to files
-         outside of the local repository */
+      /**
+       * We disable symlinks to reduce risk of access to files
+       * outside of the local repository.
+       */
       config: ['core.symlinks=false'],
 
       maxConcurrentProcesses: 1,

--- a/webapp/src/utils/lyraConfig.spec.ts
+++ b/webapp/src/utils/lyraConfig.spec.ts
@@ -141,6 +141,26 @@ describe('LyraConfig', () => {
         await expect(actual).rejects.toThrow(LyraConfigReadingError);
       });
 
+      it('throws for suspicious character in language', async () => {
+        mock({
+          '/a/lyra.yml': [
+            'projects:',
+            '- path: .',
+            '  messages:',
+            '    format: ts',
+            '    path: src',
+            '  translations:',
+            '    path: locale',
+            '  languages:',
+            '  - da',
+            '  - ..',
+            '  - sv',
+          ].join('\n'),
+        });
+        const actual = LyraConfig.readFromDir('/a');
+        await expect(actual).rejects.toThrow(LyraConfigReadingError);
+      });
+
       it('throws for file not found', async () => {
         expect.assertions(1);
         mock({

--- a/webapp/src/utils/lyraConfig.ts
+++ b/webapp/src/utils/lyraConfig.ts
@@ -57,17 +57,7 @@ export class LyraConfig {
 
       return new LyraConfig(
         parsed.projects.map((project) => {
-          const languagesEntries = (project.languages ?? []).entries();
-          for (const [index, language] of languagesEntries) {
-            if (/^[a-z]{2}$/.test(language)) {
-              continue;
-            }
-
-            throw new LyraConfigReadingError(
-              filename,
-              `invalid language at index ${index}`,
-            );
-          }
+          LyraConfig.valdidateLanguages(project.languages);
           return new LyraProjectConfig(
             repoPath,
             project.path,
@@ -79,10 +69,20 @@ export class LyraConfig {
         }),
       );
     } catch (e) {
-      if (e instanceof LyraConfigReadingError) {
-        throw e;
-      }
       throw new LyraConfigReadingError(filename, e);
+    }
+  }
+
+  private static valdidateLanguages(languages?: string[]) {
+    if (languages === undefined) {
+      return;
+    }
+    for (const [index, language] of languages.entries()) {
+      if (/^[a-z]{2}$/.test(language)) {
+        continue;
+      }
+
+      throw new SyntaxError(`invalid language at index ${index}`);
     }
   }
 }

--- a/webapp/src/utils/lyraConfig.ts
+++ b/webapp/src/utils/lyraConfig.ts
@@ -57,6 +57,17 @@ export class LyraConfig {
 
       return new LyraConfig(
         parsed.projects.map((project) => {
+          const languagesEntries = (project.languages ?? []).entries();
+          for (const [index, language] of languagesEntries) {
+            if (/^[a-z]{2}$/.test(language)) {
+              continue;
+            }
+
+            throw new LyraConfigReadingError(
+              filename,
+              `invalid language at index ${index}`,
+            );
+          }
           return new LyraProjectConfig(
             repoPath,
             project.path,
@@ -68,6 +79,9 @@ export class LyraConfig {
         }),
       );
     } catch (e) {
+      if (e instanceof LyraConfigReadingError) {
+        throw e;
+      }
       throw new LyraConfigReadingError(filename, e);
     }
   }
@@ -80,7 +94,42 @@ export class LyraProjectConfig {
     public readonly messageKind: string,
     private readonly messagesPath: string,
     private readonly translationsPath: string,
-    public readonly languages: string[], // languages in ISO 639-1 code format (en, fr, de, etc.)
+
+    /*
+     * Lyra was written primarily for Zetkin Generation 3
+     * which uses react-intl from FromatJS to format messages.
+     *
+     * FormatJS documents that it uses "locale code" defined in UTS LDML.
+     *
+     * https://formatjs.io/docs/core-concepts/basic-internationalization-principles
+     *
+     * Unicode Technical Standard Locale Data Marmkup Language
+     * does not define any locale code
+     * but they do define locale identifiers.
+     *
+     * Lower case language subtags are valid locale identifiers
+     * and will likely suffice for a long time.
+     *
+     * https://www.unicode.org/reports/tr35/tr35.html
+     *
+     * Unicode language subtags are based on BCP 47
+     * and BCP 47 includes at least many language codes from ISO 639-1
+     * but note that BCP 47 does not commit to including
+     * all languages codes of ISO 639-1.
+     *
+     * https://www.rfc-editor.org/rfc/rfc5646.html
+     *
+     * Some valid examples are:
+     * - da
+     * - de
+     * - en
+     * - nn
+     * - sv
+     *
+     * However, english is usually the language of default messages
+     * and Lyra has no support for translating default messages.
+     */
+    public readonly languages: string[],
   ) {}
 
   get absPath(): string {


### PR DESCRIPTION
By allowing strange language identifiers, and providing matching strange filenames, one who controls the repository could perhaps wreck some havoc in Lyra. Validation of language codes closes one avenue of such unintended manipulation.

This relates to #34 but is arguably not part of it.