### PR TITLE
Use GitHub's !WARNING syntax for markdown warnings

### DIFF
--- a/webapp/README.md
+++ b/webapp/README.md
@@ -9,20 +9,21 @@ source code repositories of internationalized applications.
 - Lyra can create pull requests to merge updated
   translations into the source code repository.
 
-**Warning:**
-A party who controls a source code repository branch
-which Lyra is set up to translate will also have
-a lot of control over the Lyra process. That control
-probably includes reading files from the operating system
-and possibly includes arbitrary code exection.
+> [!WARNING]
+> A party who controls a source code repository branch
+> which Lyra is set up to translate will also have
+> a lot of control over the Lyra process. That control
+> probably includes reading files from the operating system
+> and possibly includes arbitrary code exection.
 
 For each repository Lyra is set up to translate,
 Lyra needs control over a file system directory.
 
-**Warning:** A party who controls the contents of
-a local repository directory will also have
-a lot of control over the Lyra process, probably
-including arbitrary code execution.
+> [!WARNING]
+> A party who controls the contents of
+> a local repository directory will also have
+> a lot of control over the Lyra process, probably
+> including arbitrary code execution.
 
 ## Setup
 


### PR DESCRIPTION
There's a couple of security warnings in the readme. Between them there's a paragraph of text that I don't think is intended to be a warning at all. Using GitHub's built-in `> [!WARNING` markdown syntax clarifies the semantics here quite a lot.

| Before | After |
|-|-|
| ![Screenshot 2024-07-06 at 10 16 20](https://github.com/zetkin/lyra/assets/566159/fbb2be13-8ee2-4865-8b54-eaeec19b5335) | ![Screenshot 2024-07-06 at 10 16 29](https://github.com/zetkin/lyra/assets/566159/68558999-b823-418e-94a8-c57f11428513) |