### PR TITLE
Implement Message Card design

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1609,6 +1609,47 @@
         }
       }
     },
+    "node_modules/@mui/lab": {
+      "version": "5.0.0-alpha.172",
+      "resolved": "https://registry.npmjs.org/@mui/lab/-/lab-5.0.0-alpha.172.tgz",
+      "integrity": "sha512-stpa3WTsDE1HamFR4eeS6Bhxalm+u9FhzzNph/PrDMdWSRBHlJs2mqvZ6FEoO22O7MOCwNMqbXTkvEwsyEf0ew==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.9",
+        "@mui/base": "5.0.0-beta.40",
+        "@mui/system": "^5.16.1",
+        "@mui/types": "^7.2.15",
+        "@mui/utils": "^5.16.1",
+        "clsx": "^2.1.0",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.5.0",
+        "@emotion/styled": "^11.3.0",
+        "@mui/material": ">=5.15.0",
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@mui/material": {
       "version": "5.16.0",
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.16.0.tgz",
@@ -1690,12 +1731,13 @@
       }
     },
     "node_modules/@mui/private-theming": {
-      "version": "5.16.0",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.16.0.tgz",
-      "integrity": "sha512-sYpubkO1MZOnxNyVOClrPNOTs0MfuRVVnAvCeMaOaXt6GimgQbnUcshYv2pSr6PFj+Mqzdff/FYOBceK8u5QgA==",
+      "version": "5.16.1",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.16.1.tgz",
+      "integrity": "sha512-2EGCKnAlq9vRIFj61jNWNXlKAxXp56577OVvsts7fAqRx+G1y6F+N7Q198SBaz8jYQeGKSz8ZMXK/M3FqjdEyw==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.23.9",
-        "@mui/utils": "^5.16.0",
+        "@mui/utils": "^5.16.1",
         "prop-types": "^15.8.1"
       },
       "engines": {
@@ -1716,7 +1758,9 @@
       }
     },
     "node_modules/@mui/styled-engine": {
-      "version": "5.15.14",
+      "version": "5.16.1",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.16.1.tgz",
+      "integrity": "sha512-JwWUBaYR8HHCFefSeos0z6JoTbu0MnjAuNHu4QoDgPxl2EE70XH38CsKay66Iy0QkNWmGTRXVU2sVFgUOPL/Dw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.23.9",
@@ -1746,15 +1790,16 @@
       }
     },
     "node_modules/@mui/system": {
-      "version": "5.16.0",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.16.0.tgz",
-      "integrity": "sha512-9YbkC2m3+pNumAvubYv+ijLtog6puJ0fJ6rYfzfLCM47pWrw3m+30nXNM8zMgDaKL6vpfWJcCXm+LPaWBpy7sw==",
+      "version": "5.16.1",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.16.1.tgz",
+      "integrity": "sha512-VaFcClC+uhvIEzhzcNmh9FRBvrG9IPjsOokhj6U1HPZsFnLzHV7AD7dJcT6LxWoiIZj9Ej0GK+MGh/b8+BtSlQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.23.9",
-        "@mui/private-theming": "^5.16.0",
-        "@mui/styled-engine": "^5.15.14",
-        "@mui/types": "^7.2.14",
-        "@mui/utils": "^5.16.0",
+        "@mui/private-theming": "^5.16.1",
+        "@mui/styled-engine": "^5.16.1",
+        "@mui/types": "^7.2.15",
+        "@mui/utils": "^5.16.1",
         "clsx": "^2.1.0",
         "csstype": "^3.1.3",
         "prop-types": "^15.8.1"
@@ -1785,7 +1830,9 @@
       }
     },
     "node_modules/@mui/types": {
-      "version": "7.2.14",
+      "version": "7.2.15",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.15.tgz",
+      "integrity": "sha512-nbo7yPhtKJkdf9kcVOF8JZHPZTmqXjJ/tI0bdWgHg5tp9AnIN4Y7f7wm9T+0SyGYJk76+GYZ8Q5XaTYAsUHN0Q==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^17.0.0 || ^18.0.0"
@@ -1797,14 +1844,15 @@
       }
     },
     "node_modules/@mui/utils": {
-      "version": "5.16.0",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.16.0.tgz",
-      "integrity": "sha512-kLLi5J1xY+mwtUlMb8Ubdxf4qFAA1+U7WPBvjM/qQ4CIwLCohNb0sHo1oYPufjSIH/Z9+dhVxD7dJlfGjd1AVA==",
+      "version": "5.16.1",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.16.1.tgz",
+      "integrity": "sha512-4UQzK46tAEYs2xZv79hRiIc3GxZScd00kGPDadNrGztAEZlmSaUY8cb9ITd2xCiTfzsx5AN6DH8aaQ8QEKJQeQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.23.9",
-        "@types/prop-types": "^15.7.11",
+        "@types/prop-types": "^15.7.12",
         "prop-types": "^15.8.1",
-        "react-is": "^18.2.0"
+        "react-is": "^18.3.1"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -2432,9 +2480,9 @@
       "license": "MIT"
     },
     "node_modules/@types/prop-types": {
-      "version": "15.7.11",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.11.tgz",
-      "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==",
+      "version": "15.7.12",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.12.tgz",
+      "integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==",
       "license": "MIT"
     },
     "node_modules/@types/react": {
@@ -10558,9 +10606,9 @@
       }
     },
     "node_modules/react-is": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "license": "MIT"
     },
     "node_modules/react-transition-group": {
@@ -12007,6 +12055,7 @@
         "@emotion/react": "^11.11.4",
         "@emotion/styled": "^11.11.5",
         "@mui/icons-material": "^5.15.21",
+        "@mui/lab": "^5.0.0-alpha.172",
         "@mui/material": "^5.15.21",
         "@mui/material-nextjs": "^5.15.11",
         "@mui/x-tree-view": "^7.8.0",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -16,6 +16,7 @@
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.5",
     "@mui/icons-material": "^5.15.21",
+    "@mui/lab": "^5.0.0-alpha.172",
     "@mui/material": "^5.15.21",
     "@mui/material-nextjs": "^5.15.11",
     "@mui/x-tree-view": "^7.8.0",

--- a/webapp/src/components/MessageForm.tsx
+++ b/webapp/src/components/MessageForm.tsx
@@ -1,18 +1,17 @@
 'use client';
 
+import { Check, Error, RestartAlt } from '@mui/icons-material';
 import {
   Alert,
   Box,
   Button,
-  CircularProgress,
-  Grid,
-  List,
-  ListItem,
+  ButtonGroup,
   Snackbar,
   TextField,
   Typography,
 } from '@mui/material';
-import { FC, useCallback, useEffect, useRef, useState } from 'react';
+import { LoadingButton } from '@mui/lab';
+import { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTheme } from '@mui/material';
 
 import updateTranslation, {
@@ -20,8 +19,15 @@ import updateTranslation, {
 } from '@/actions/updateTranslation';
 import { type MessageData } from '@/utils/adapters';
 
+export type MessageFormLayout = 'linear' | 'grid';
+
+export function messageFormHeight(layout: MessageFormLayout): number {
+  return layout === 'linear' ? 300 : 220;
+}
+
 type MessageFormProps = {
   languageName: string;
+  layout: MessageFormLayout;
   message: MessageData;
   projectName: string;
   translation: string;
@@ -29,12 +35,14 @@ type MessageFormProps = {
 
 const MessageForm: FC<MessageFormProps> = ({
   languageName,
+  layout,
   message,
   projectName,
   translation,
 }) => {
   const theme = useTheme();
   const resetValue = useRef(translation);
+
   const [state, setState] = useState<TranslationState>({
     translationStatus: 'idle',
     translationText: translation,
@@ -59,7 +67,10 @@ const MessageForm: FC<MessageFormProps> = ({
   );
 
   const onSave = useCallback(async () => {
-    if (state.translationStatus !== 'modified') {
+    if (
+      state.translationStatus !== 'modified' &&
+      state.translationStatus !== 'error'
+    ) {
       return;
     }
     setState({
@@ -85,6 +96,7 @@ const MessageForm: FC<MessageFormProps> = ({
       state.translationText,
       state.original,
     );
+
     if (response.translationStatus === 'success') {
       resetValue.current = response.translationText;
     }
@@ -98,6 +110,7 @@ const MessageForm: FC<MessageFormProps> = ({
         s.translationStatus === 'error'
       ) {
         return {
+          original: s.original,
           translationStatus: 'idle',
           translationText: s.original,
         };
@@ -125,102 +138,156 @@ const MessageForm: FC<MessageFormProps> = ({
     });
   }, []);
 
+  const messageIdParts = useMemo(() => message.id.split('.'), [message.id]);
+
   return (
     <>
-      <Grid
-        key={message.id}
-        alignContent="center"
-        px={2}
-        spacing={2}
-        sx={{ height: '200px', width: '100%' }}
+      <Box
+        sx={{
+          ':focus-within, :hover': {
+            backgroundColor: theme.palette.grey[50],
+            outlineColor: theme.palette.primary.main,
+            outlineStyle: 'solid',
+            outlineWidth: 1,
+          },
+          backgroundColor: '#fafcfe',
+          borderRadius: 2,
+          display: 'flex',
+          marginLeft: theme.spacing(2),
+          marginRight: theme.spacing(2),
+          maxHeight: `${messageFormHeight(layout)}px`,
+          maxWidth: '100%',
+          overflow: 'hidden',
+          padding: theme.spacing(2),
+          position: 'relative',
+          width: '100%',
+          ...(layout === 'linear'
+            ? {
+                flexDirection: 'column',
+                rowGap: theme.spacing(2),
+              }
+            : {
+                columnGap: theme.spacing(2),
+                flexDirection: 'row',
+              }),
+        }}
       >
-        <Grid md={6} overflow="hidden" textOverflow="ellipsis" xs={12}>
-          <code>{message.id}</code>
-          <Typography>{message.defaultMessage}</Typography>
-        </Grid>
-        <Grid md={6} xs={12}>
-          <Box display="flex" flexDirection="row" gap={1}>
-            <TextField
-              aria-readonly={state.translationStatus === 'updating'}
-              InputProps={{ readOnly: state.translationStatus === 'updating' }}
-              maxRows={2}
-              minRows={2}
-              multiline
-              onChange={onChange}
-              sx={{ flexGrow: 1 }}
-              value={state.translationText}
-            />
-            {(state.translationStatus === 'modified' ||
-              state.translationStatus === 'error') && (
-              <Button onClick={onSave}>Save</Button>
-            )}
-            {state.translationStatus === 'updating' && (
-              <Button aria-label="Saving" disabled>
-                <CircularProgress />
-              </Button>
-            )}
+        <Box sx={{ flex: 1, maxWidth: '100%', overflow: 'hidden' }}>
+          <Typography
+            component="h2"
+            maxWidth="100%"
+            overflow="hidden"
+            textOverflow="ellipsis"
+            whiteSpace="nowrap"
+            width="100%"
+          >
+            {messageIdParts.map((part, i) => (
+              <Typography
+                key={part}
+                color={
+                  i === messageIdParts.length - 1
+                    ? 'text.primary'
+                    : 'text.secondary'
+                }
+                component="span"
+              >
+                {part}
+                {i < messageIdParts.length - 1 && '.'}
+              </Typography>
+            ))}
+          </Typography>
+          <Typography color="text.primary">{message.defaultMessage}</Typography>
+        </Box>
+        <Box
+          sx={{
+            display: 'flex',
+            flex: 1,
+            flexDirection: 'column',
+            rowGap: theme.spacing(1),
+          }}
+        >
+          <TextField
+            aria-readonly={state.translationStatus === 'updating'}
+            fullWidth
+            InputLabelProps={{ shrink: true }}
+            InputProps={{ readOnly: state.translationStatus === 'updating' }}
+            label="Translation"
+            maxRows={4}
+            minRows={4}
+            multiline
+            onChange={onChange}
+            sx={{ flexGrow: 1 }}
+            value={state.translationText}
+          />
+          <ButtonGroup
+            aria-label="Translation actions"
+            sx={{ justifyContent: 'flex-end' }}
+          >
             {(state.translationStatus === 'modified' ||
               state.translationStatus === 'error' ||
               state.translationStatus === 'updating') && (
               <Button
-                aria-label="Reset"
                 disabled={state.translationStatus === 'updating'}
                 onClick={onReset}
-                variant="outlined"
+                startIcon={<RestartAlt />}
               >
-                ↺
+                Reset
               </Button>
             )}
-          </Box>
-          {!!message.params.length && (
-            <Box>
-              <Typography>You can use the following parameters:</Typography>
-              <List
-                sx={{
-                  columnGap: theme.spacing(1),
-                  display: 'flex',
-                  flexDirection: 'row',
-                }}
-              >
-                {message.params.map((param) => {
-                  return (
-                    <ListItem
-                      key={param.name}
-                      sx={{ padding: 0, width: 'auto' }}
-                    >
-                      <code>{param.name}</code>
-                    </ListItem>
-                  );
-                })}
-              </List>
-            </Box>
-          )}
-        </Grid>
-      </Grid>
-      {state.translationStatus === 'success' && (
-        <Snackbar open>
-          <Alert
-            onClose={onDismissSnackbar}
-            severity="success"
-            sx={{ width: '100%' }}
-            variant="filled"
-          >
-            Translation updated
-          </Alert>
-        </Snackbar>
-      )}
-      {state.translationStatus === 'error' && (
-        <Snackbar open>
-          <Alert
-            onClose={onDismissSnackbar}
-            severity="error"
-            sx={{ width: '100%' }}
-            variant="filled"
-          >
-            {state.errorMessage}
-          </Alert>
-        </Snackbar>
-      )}
+            <LoadingButton
+              disabled={
+                state.translationStatus === 'idle' ||
+                state.translationStatus === 'success'
+              }
+              loading={state.translationStatus === 'updating'}
+              loadingPosition="start"
+              onClick={onSave}
+              startIcon={
+                state.translationStatus === 'idle' &&
+                state.translationText === '' ? (
+                  <Error />
+                ) : (
+                  <Check />
+                )
+              }
+              sx={{ minWidth: 'max-content' }}
+            >
+              {state.translationStatus === 'idle'
+                ? state.translationText
+                  ? 'Published'
+                  : 'Missing'
+                : state.translationStatus === 'success'
+                  ? 'Updated'
+                  : 'Save'}
+            </LoadingButton>
+          </ButtonGroup>
+        </Box>
+
+        {state.translationStatus === 'success' && (
+          <Snackbar open sx={{ position: 'absolute' }}>
+            <Alert
+              onClose={onDismissSnackbar}
+              severity="success"
+              sx={{ width: '100%' }}
+              variant="filled"
+            >
+              Translation updated
+            </Alert>
+          </Snackbar>
+        )}
+        {state.translationStatus === 'error' && (
+          <Snackbar open sx={{ position: 'absolute' }}>
+            <Alert
+              onClose={onDismissSnackbar}
+              severity="error"
+              sx={{ width: '100%' }}
+              variant="filled"
+            >
+              {state.errorMessage}
+            </Alert>
+          </Snackbar>
+        )}
+      </Box>
     </>
   );
 };

--- a/webapp/src/components/MessageForm.tsx
+++ b/webapp/src/components/MessageForm.tsx
@@ -104,13 +104,12 @@ const MessageForm: FC<MessageFormProps> = ({
   }, [languageName, message.id, projectName, state]);
 
   const onReset = useCallback(() => {
-    setState((s) => {
+    setState((s): TranslationState => {
       if (
         s.translationStatus === 'modified' ||
         s.translationStatus === 'error'
       ) {
         return {
-          original: s.original,
           translationStatus: 'idle',
           translationText: s.original,
         };

--- a/webapp/src/components/MessageList.tsx
+++ b/webapp/src/components/MessageList.tsx
@@ -3,12 +3,9 @@
 import ListItem from '@mui/material/ListItem';
 import { FC, useCallback, useEffect, useState } from 'react';
 import { FixedSizeList, ListChildComponentProps } from 'react-window';
-import { useTheme } from '@mui/material';
+import { useMediaQuery, useTheme } from '@mui/material';
 
-import MessageForm, {
-  messageFormHeight,
-  MessageFormLayout,
-} from '@/components/MessageForm';
+import MessageForm, { messageFormHeight } from '@/components/MessageForm';
 import { MessageData } from '@/utils/adapters';
 
 type MessageListProps = {
@@ -26,14 +23,13 @@ const MessageList: FC<MessageListProps> = ({
 }) => {
   const theme = useTheme();
   const [height, setHeight] = useState<number | undefined>(undefined);
-  const [layout, setLayout] = useState<MessageFormLayout>('linear');
+
+  const lg = useMediaQuery(theme.breakpoints.up('lg'));
+  const layout = lg ? 'grid' : 'linear';
 
   const onResize = useCallback(() => {
     setHeight(window.innerHeight);
-    setLayout(
-      window.innerWidth > theme.breakpoints.values.lg ? 'grid' : 'linear',
-    );
-  }, [theme.breakpoints.values.lg]);
+  }, []);
 
   useEffect(() => {
     if (typeof window === 'object') {

--- a/webapp/src/theme.ts
+++ b/webapp/src/theme.ts
@@ -11,6 +11,15 @@ const roboto = Roboto({
 
 const theme = createTheme({
   components: {
+    MuiButton: {
+      styleOverrides: {
+        root: () => ({
+          ':disabled': {
+            color: '#666',
+          },
+        }),
+      },
+    },
     MuiLinearProgress: {
       styleOverrides: {
         root: () => ({


### PR DESCRIPTION
#82

## Layout

Switches from a linear columnar layout to a side-by-side grid layout at the `lg` breakpoint.

![2024-07-15 21 23 52](https://github.com/user-attachments/assets/bf8de721-3410-49cd-874e-fdc42997a967)

## FixedSizeList and messageFormHeight

On narrower devices, the MessageForm component's layout is linearised in order to fit everything in despite the lack of horizontal space. An increase in height is necessary for this. Its parent component, MessageList, needs to be able to configure a fixed height value to enable the virtualisation. So MessageForm exports a `messageFormHeight` function for this purpose.

## Buttons and the button group

As we have a little group of buttons underneath the text area, MUI's [ButtonGroup](https://mui.com/material-ui/react-button-group/) component seemed like a natural fit. And since we have a save button with a loading status, it seemed equally natural to pull in [LoadingButton](https://mui.com/material-ui/react-button/#loading-button) from @mui/lab. In their default form these vary a teeny tiny bit in appearance as compared to the designs, but I don't think it's a big deal.

## Success

![2024-07-15 21 22 22](https://github.com/user-attachments/assets/0a8ada6d-acc8-44cc-92d3-8690ef8e2c17)

## Failure

![2024-07-15 21 21 30](https://github.com/user-attachments/assets/79895619-d2f0-470d-bb7f-143a495ac476)

## Reset button

This doesn't actually feature in the design but I figured it was easier to preserve it for the sake of this pull request as it is quite a nice little extra feature.

![2024-07-15 21 20 24](https://github.com/user-attachments/assets/6c215ce9-4d72-4c70-a95c-4c1579f58363)

## Message params

These are going to be challenging enough to display that I think we should postpone implementing them. It will probably require moving MessageList to [VariableSizeList](https://react-window.vercel.app/#/api/VariableSizeList). I think it'll be interesting enough that it should be tackled in a pull request of its own once this foundation is in place.

## Textarea rows

As the virtualisation imposes a fixed height on each MessageForm, it's helpful for elements to vary in size as little as possible, so I've set the translation input field textarea to be four rows high all the time.

## Text size at 200% zoom

This is a pretty crowded layout, and the fixed height of the virtualisation imposes a rigidity that makes handling different zoom levels challenging. It's still operable at 200% zoom though, which is good enough for [WCAG success criterion 1.4.4](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-scale.html). Would ideally like to tweak it so that the layout linearises above a certain zoom level but am mindful of the risk of being self-indulgent in overprioritising accessibility minutiae since it's my fav stuff to work on.

![2024-07-15 21 42 42](https://github.com/user-attachments/assets/eaa0c68d-c8d6-475e-a030-646ebefbea52)

