### PR TITLE
Add uuid snippet to branch name

### DIFF
--- a/webapp/.gitignore
+++ b/webapp/.gitignore
@@ -18,7 +18,6 @@
 # misc
 .DS_Store
 *.pem
-ideas.md
 
 # debug
 npm-debug.log*

--- a/webapp/.gitignore
+++ b/webapp/.gitignore
@@ -18,6 +18,7 @@
 # misc
 .DS_Store
 *.pem
+ideas.md
 
 # debug
 npm-debug.log*

--- a/webapp/src/actions/createPullRequest.ts
+++ b/webapp/src/actions/createPullRequest.ts
@@ -83,7 +83,7 @@ export default async function sendPullRequest(
 
     const pullRequestUrl = await repoGit.createPR(
       branchName,
-      'LYRA Translate PR: ' + uuidSnippet,
+      'LYRA Translate PR: ' + nowIso,
       'Created by LYRA at: ' + nowIso,
       serverProjectConfig.owner,
       serverProjectConfig.repo,

--- a/webapp/src/actions/createPullRequest.ts
+++ b/webapp/src/actions/createPullRequest.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { notFound } from 'next/navigation';
+import { randomUUID } from 'crypto';
 
 import { RepoGit } from '@/RepoGit';
 import { ServerConfig, ServerProjectConfig } from '@/utils/serverConfig';
@@ -71,16 +72,18 @@ export default async function sendPullRequest(
     }
 
     const nowIso = new Date().toISOString().replace(/:/g, '').split('.')[0];
-    const branchName = 'lyra-translate-' + nowIso;
+    const uuidSnippet = randomUUID().substring(5);
+    const branchName = 'lyra-translate-' + uuidSnippet;
+    
     await repoGit.newBranchCommitAndPush(
       branchName,
       langFilePaths,
-      `Lyra translate: ${nowIso}`,
+      `Lyra translate: ${nowIso}-${uuidSnippet} `,
     );
 
     const pullRequestUrl = await repoGit.createPR(
       branchName,
-      'LYRA Translate PR: ' + nowIso,
+      'LYRA Translate PR: ' + uuidSnippet,
       'Created by LYRA at: ' + nowIso,
       serverProjectConfig.owner,
       serverProjectConfig.repo,

--- a/webapp/src/actions/createPullRequest.ts
+++ b/webapp/src/actions/createPullRequest.ts
@@ -74,11 +74,11 @@ export default async function sendPullRequest(
     const nowIso = new Date().toISOString().replace(/:/g, '').split('.')[0];
     const uuidSnippet = randomUUID().substring(5);
     const branchName = 'lyra-translate-' + uuidSnippet;
-    
+
     await repoGit.newBranchCommitAndPush(
       branchName,
       langFilePaths,
-      `Lyra translate: ${nowIso}-${uuidSnippet} `,
+      `Lyra translate: ${nowIso}-${uuidSnippet}`,
     );
 
     const pullRequestUrl = await repoGit.createPR(


### PR DESCRIPTION
# Add UUID snippet to PR generation

This adds a UUID snippet instead of a date string to the generated branch name used in the PR automation. 

## Background 

Theoretically multiple branches with the same name could be created when using a string of Date.now() formatted as YYYY-mm-dd-hh:mm:ss as postfix to the branch submitted with the PR.

resolves #57 