### PR TITLE
Extract MessagesPage data loading to dataAccess module

### DIFF
--- a/webapp/src/app/projects/[projectName]/[languageName]/page.tsx
+++ b/webapp/src/app/projects/[projectName]/[languageName]/page.tsx
@@ -15,29 +15,19 @@ import PullRequestButton from '@/components/PullRequestButton';
 import TitleBar from '@/components/TitleBar';
 import SidebarContextProvider from '@/components/SidebarContext';
 import { getTranslationsIdText } from '@/utils/translationObjectUtil';
+import { accessLanguage } from '@/dataAccess';
 
 const MessagesPage: NextPage<{
   params: { languageName: string; messageId?: string; projectName: string };
 }> = async ({ params }) => {
   const { languageName, messageId, projectName } = params;
 
-  const serverConfig = await ServerConfig.read();
-  const project = serverConfig.projects.find(
-    (project) => project.name === projectName,
-  );
-
-  if (!project) {
+  const languageData = await accessLanguage(projectName, languageName);
+  if (!languageData) {
     return notFound();
   }
 
-  await RepoGit.cloneIfNotExist(project);
-  const repoGit = await RepoGit.getRepoGit(project);
-  const lyraConfig = await repoGit.getLyraConfig();
-  const projectConfig = lyraConfig.getProjectConfigByPath(project.projectPath);
-  const msgAdapter = MessageAdapterFactory.createAdapter(projectConfig);
-  const messages = await msgAdapter.getMessages();
-  const translations = await Cache.getLanguage(projectName, languageName);
-  const translationsIdText = getTranslationsIdText(translations);
+  const { messages, translations } = languageData;
 
   const prefix = messageId ? messageId : '';
   const filteredMessages = messages.filter((message) =>
@@ -49,8 +39,8 @@ const MessagesPage: NextPage<{
   }
 
   filteredMessages.sort((m0, m1) => {
-    const trans0 = translations[m0.id]?.text.trim() ?? '';
-    const trans1 = translations[m1.id]?.text.trim() ?? '';
+    const trans0 = translations[m0.id]?.trim() ?? '';
+    const trans1 = translations[m1.id]?.trim() ?? '';
 
     if (!trans0) {
       return -1;
@@ -85,7 +75,7 @@ const MessagesPage: NextPage<{
           languageName={languageName}
           messages={filteredMessages}
           projectName={projectName}
-          translations={translationsIdText}
+          translations={translations}
         />
       </Main>
     </Box>

--- a/webapp/src/app/projects/[projectName]/[languageName]/page.tsx
+++ b/webapp/src/app/projects/[projectName]/[languageName]/page.tsx
@@ -5,16 +5,11 @@ import { notFound } from 'next/navigation';
 import Header from '@/components/Header';
 import Main from '@/components/Main';
 import Sidebar from '@/components/Sidebar';
-import { Cache } from '@/Cache';
-import MessageAdapterFactory from '@/utils/adapters/MessageAdapterFactory';
-import { RepoGit } from '@/RepoGit';
-import { ServerConfig } from '@/utils/serverConfig';
 import MessageTree from '@/components/MessageTree';
 import MessageList from '@/components/MessageList';
 import PullRequestButton from '@/components/PullRequestButton';
 import TitleBar from '@/components/TitleBar';
 import SidebarContextProvider from '@/components/SidebarContext';
-import { getTranslationsIdText } from '@/utils/translationObjectUtil';
 import { accessLanguage } from '@/dataAccess';
 
 const MessagesPage: NextPage<{


### PR DESCRIPTION
This PR moves the data loading required for `MessagesPage` to the `dataAccess` module as a first step towards implementing cache revaliation. See issue #25 for game plan and motivations.

This is joint work by me and @WULCAN. We realized that further extraction and refactoring is possible, but chose not to do it now as it is not crucial for the cache issue, and can be done at a later point.