### PR TITLE
Pad Home page

### DIFF
--- a/webapp/src/components/HomeDashboard.tsx
+++ b/webapp/src/components/HomeDashboard.tsx
@@ -16,6 +16,7 @@ const HomeDashboard: FC<HomeDashboardProps> = ({ projects }) => {
       flexDirection="column"
       justifyContent="center"
       minHeight="97vh"
+      p={2}
     >
       <CardGrid
         heading={


### PR DESCRIPTION
## Description
This PR adds padding to the home page so that content no longer touches the window edge when the window is small.

## Notes to reviewer

Try it out with larger and smaller windows.

## Related issues
This related to #71 but does not resolve it.