### PR TITLE
Generate source file without leading slash

### DIFF
--- a/webapp/src/store/ProjectStore.spec.ts
+++ b/webapp/src/store/ProjectStore.spec.ts
@@ -140,6 +140,37 @@ describe('ProjectStore', () => {
     });
   });
 
+  describe('updateTranslation', () => {
+    it('does not prefix source file with /', async () => {
+      const store = new ProjectStore(
+        {
+          getMessages: async () => [
+            {
+              defaultMessage: 'Click',
+              id: 'core.click',
+              params: [],
+            },
+          ],
+        },
+        {
+          getTranslations: async () => ({
+            en: {
+              'core.click': {
+                sourceFile: 'en.yml',
+                text: 'Click',
+              },
+            },
+          }),
+        },
+      );
+
+      await store.updateTranslation('sv', 'core.click', 'Klicka');
+
+      const actual = await store.getTranslations('sv');
+      expect(actual['core.click'].sourceFile).toEqual('sv.yml');
+    });
+  });
+
   it('gives full access to all languages', async () => {
     const msgAdapter = mockMsgAdapter();
     msgAdapter.getMessages.mockResolvedValue([

--- a/webapp/src/store/ProjectStore.ts
+++ b/webapp/src/store/ProjectStore.ts
@@ -100,6 +100,7 @@ export class ProjectStore {
       /^en\.(.+\.)*(ya?ml)$/g,
       `${lang}.$1$2`,
     );
-    return enSourceFileArr.join('/').concat(`/${langFileName}`);
+    enSourceFileArr.push(langFileName);
+    return enSourceFileArr.join('/');
   }
 }


### PR DESCRIPTION
## Description
This PR fixes a bug where new translations got a source file prefixed with /, like an asbolute path, when the english translation's sourcefile was in the root of the translation path.

Source files prefixed with slash breaks the code that writes translations to disk when we create pull requests.

## Related issues
This relates to #126
