### PR TITLE
fix error throwing in save message

### DIFF
--- a/webapp/src/actions/updateTranslation.ts
+++ b/webapp/src/actions/updateTranslation.ts
@@ -85,7 +85,12 @@ export default async function updateTranslation(
   const foundId = messageIds.find((id) => id == messageId);
 
   if (foundId === undefined) {
-    throw new MessageNotFound(languageName, messageId);
+    return {
+      errorMessage: 'Message Id not found',
+      original,
+      translationStatus: 'error',
+      translationText: translation,
+    };
   }
 
   try {


### PR DESCRIPTION
## Description
fix error thrown on saving translation
prior to the fix, on click on save, it only kept 'thinking' forever

## Changes
replace 'throw' with a return error message object

## Notes to reviewer
thank you for all your help
tested the issue by changing the if statement to if (true) in order to see the error no matter what

## Related issues
Resolves #146