### PR TITLE
Relax ESLint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -34,7 +34,7 @@ module.exports = {
       rules: {
         "@typescript-eslint/no-non-null-assertion": "off",
         "@typescript-eslint/explicit-module-boundary-types": "off",
-        "@typescript-eslint/no-unused-vars": ["error"],
+        "@typescript-eslint/no-unused-vars": ["warn"],
         "@typescript-eslint/member-ordering": [
           "error",
           {

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,8 +14,9 @@ This PR…
 
 
 ## Notes to reviewer
-[Add instructions for testing]
+Review the output of our GitHub action 'Test & Lint' for warnings.
 
+[Add more instructions for testing]
 
 ## Related issues
 Resolves #[id]


### PR DESCRIPTION
## Description
This PR relaxes our ESLint configurtion to warn instead of fail the build on unused variables.

In #152 this rule blocks merging even though the added value from the pull request by far outweighs the introduced inconvenience. The reviewer can decide for herself instead wether unused variables needs to be fixed before or after merging.

See https://eslint.org/docs/v8.x/use/configure/rules for documentation.

## Screenshots
![image](https://github.com/user-attachments/assets/c033927c-90a1-4686-aa01-5d1b0f08858b)

![image](https://github.com/user-attachments/assets/f9eba9da-d176-499b-a28b-1f7e99d07e15)

## Changes

* Changes the rule to severity `warn`
* Adds review of Test & Lint action output.

## Related issues
Resolves pull request #152
