### PR TITLE
Remove job stories from issue issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -10,8 +10,6 @@ assignees: ''
 
 A user should be able to...
 
-## Relevant Job Stories
-
 ## Estimated size (S, M, L)
 
 I think this issue is {size} because...


### PR DESCRIPTION
## Description
This pull request removes job stories from our issue template.

Job stories were used previously in Zetkin, but not any more, and never for Lyra.