### PR TITLE
Automatically configure Prettier for VS Code

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["esbenp.prettier-vscode"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "editor.defaultFormatter": "esbenp.prettier-vscode"
+}

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -37,17 +37,7 @@ you can take to setup your develop environment.
 
 #### Prettier
 
-1. Install the extension `Prettier - Code formatter`.
-   It has an identifier `esbenp.prettier-vscode`.
-2. Configure Prettier as the default formatter.
-
-Steps 2 can be done with a `.vscode/settings.json`:
-
-```
-{
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
-}
-```
+Install the recommended extension `Prettier - Code formatter`.
 
 #### PlantUML
 


### PR DESCRIPTION
## Description
This PR configures Prettier as the default formatter in VS Code, so that developers do not have to configure it.

It also adds the extenension as a Recommended Extension to make it easier to install.