### PR TITLE
Remove docker/setup-docker-action

### DIFF
--- a/.github/workflows/build-and-push-image.yaml
+++ b/.github/workflows/build-and-push-image.yaml
@@ -14,9 +14,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Set up Docker
-        uses: docker/setup-docker-action@v4
-
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v2
         with:


### PR DESCRIPTION
## Description

This PR removes docker/setup-docker-action

We are using GitHub-hosted runners on Linux so Docker is already up and running. It is not necessary to use docker/setup-docker-action

https://github.com/docker/setup-docker-action/blob/efe6ba76e30de04f1a84d4aa6ea0d802d73b31b9/README.md?plain=1#L12-L17.

https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md#tools

## Related issues
This is an amendment to pul request #157
