### PR TITLE
Remove eslint-plugin-next

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-import": "^2.29.1",
         "eslint-plugin-jsx-a11y": "^6.4.1",
-        "eslint-plugin-next": "^0.0.0",
         "eslint-plugin-no-switch-statements": "^1.0.0",
         "eslint-plugin-react": "^7.37.2",
         "eslint-plugin-react-hooks": "^5.1.0",
@@ -4627,13 +4626,6 @@
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/eslint-plugin-next": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-next/-/eslint-plugin-next-0.0.0.tgz",
-      "integrity": "sha512-IldNDVb6WNduggwRbYzSGZhaskUwVecJ6fhmqwX01+S1aohwAWNzU4me6y47DDzpD/g0fdayNBGxEdt9vKkUtg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-jsx-a11y": "^6.4.1",
-    "eslint-plugin-next": "^0.0.0",
     "eslint-plugin-no-switch-statements": "^1.0.0",
     "eslint-plugin-react": "^7.37.2",
     "eslint-plugin-react-hooks": "^5.1.0",


### PR DESCRIPTION
## Description
This PR remove eslint-plugin-next

In e27f9cc5464ccc0a7c8a7eabe2c29d1869515f83 we copied a dependency on eslint-plugin-next 0.0.0 from https://github.com/zetkin/app.zetkin.org/pull/559

The package is empty and does not originate from Next.js or Vercel.

In https://github.com/zetkin/app.zetkin.org/pull/2795, app.zetkin.org removed their dependency on the package.

I used npm uninstall eslint-plugin-next from npm 10.9.2

## Notes to reviewer
Review the output of our GitHub action 'Test & Lint' for warnings.

## Related issues
Resolves #197