### PR TITLE
Refresh lesser

### DIFF
--- a/webapp/CHANGELOG.md
+++ b/webapp/CHANGELOG.md
@@ -40,19 +40,19 @@
 
 - Layout file for messages tree
 
-## [0.5.0] - 2025-06-07
+# [0.5.0] - 2025-06-07
 
 ### Removed
 
 - Publish button from webapp
 
-## [0.4.1] - 2025-06-07
+# [0.4.1] - 2025-06-07
 
 ### Added
 
 - Debug logging flagged with env var
 
-## [0.4.0] - 2025-06-06
+# [0.4.0] - 2025-06-06
 
 ### Added
 

--- a/webapp/CHANGELOG.md
+++ b/webapp/CHANGELOG.md
@@ -40,19 +40,19 @@
 
 - Layout file for messages tree
 
-# [0.5.0] - 2025-06-07
+## [0.5.0] - 2025-06-07
 
 ### Removed
 
 - Publish button from webapp
 
-# [0.4.1] - 2025-06-07
+## [0.4.1] - 2025-06-07
 
 ### Added
 
 - Debug logging flagged with env var
 
-# [0.4.0] - 2025-06-06
+## [0.4.0] - 2025-06-06
 
 ### Added
 

--- a/webapp/CHANGELOG.md
+++ b/webapp/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 
+- Reduce load times by not refreshing ProjectStore if we skipped fetch.
 - Reduce load times by not refreshing ProjectStore many times per page load.
 
 ### Changed

--- a/webapp/src/RepoGit.ts
+++ b/webapp/src/RepoGit.ts
@@ -106,9 +106,9 @@ export class RepoGit {
 
   /**
    * Fetch then checkout origin/<base branch>
-   * @returns base branch name
+   * @returns true if we fetched, false if we skipped fetch
    */
-  public async fetchAndCheckoutOriginBase(): Promise<string> {
+  public async fetchAndCheckoutOriginBase(): Promise<boolean> {
     const now = new Date();
     const age = now.getTime() - this.lastPullTime.getTime();
     if (age > this.GIT_FETCH_TTL) {
@@ -119,8 +119,9 @@ export class RepoGit {
       await this.git.fetch();
       await this.git.checkout(this.spConfig.originBaseBranch);
       this.lastPullTime = now;
+      return true;
     }
-    return this.spConfig.originBaseBranch;
+    return false;
   }
 
   public async saveLanguageFiles(projectPath: string): Promise<string[]> {

--- a/webapp/src/app/api/projects/[projectName]/pull-requests/route.ts
+++ b/webapp/src/app/api/projects/[projectName]/pull-requests/route.ts
@@ -63,12 +63,13 @@ export async function POST(
   try {
     syncLock.set(repoPath, true);
     const repoGit = await RepoGit.get(serverProjectConfig);
-    const baseBranch = await repoGit.fetchAndCheckoutOriginBase();
+    await repoGit.fetchAndCheckoutOriginBase();
     const langFilePaths = await repoGit.saveLanguageFiles(
       serverProjectConfig.projectPath,
     );
 
     if (!(await repoGit.statusChanged())) {
+      const baseBranch = serverProjectConfig.originBaseBranch;
       return NextResponse.json({
         errorMessage: `There are no changes in ${baseBranch} branch`,
         pullRequestStatus: 'error',

--- a/webapp/src/dataAccess.ts
+++ b/webapp/src/dataAccess.ts
@@ -38,11 +38,13 @@ export async function accessLanguage(
   }
 
   const repoGit = await RepoGit.get(project);
-  await repoGit.fetchAndCheckoutOriginBase();
+  const fetched = await repoGit.fetchAndCheckoutOriginBase();
   const lyraConfig = await repoGit.getLyraConfig();
   const projectConfig = lyraConfig.getProjectConfigByPath(project.projectPath);
   const projectStore = await Store.getProjectStore(projectConfig);
-  await projectStore.refresh();
+  if (fetched) {
+    await projectStore.refresh();
+  }
   const messages = await projectStore.getMessages();
 
   if (!projectConfig.isLanguageSupported(languageName)) {
@@ -65,11 +67,13 @@ async function readProject(project: ServerProjectConfig) {
     return { languagesWithTranslations: [], messages: [], name: project.name };
   }
   const repoGit = await RepoGit.get(project);
-  await repoGit.fetchAndCheckoutOriginBase();
+  const fetched = await repoGit.fetchAndCheckoutOriginBase();
   const lyraConfig = await repoGit.getLyraConfig();
   const projectConfig = lyraConfig.getProjectConfigByPath(project.projectPath);
   const store = await Store.getProjectStore(projectConfig);
-  await store.refresh();
+  if (fetched) {
+    await store.refresh();
+  }
   const messages = await store.getMessages();
   const languagesWithTranslations = projectConfig.languages.map(
     async (lang) => {


### PR DESCRIPTION
## Description
This PR reduces load times by skipping ProjectStore.refresh if we skipped fetch.

If fetchAndCheckoutOriginBase was called so recently that we don't even need to fetch again, then there are no new messages or translations to read from file system and merge into project store.

Note that posting a new translation or creating a pull-request still calls the refresh every time. These operations do not explicitly fetch at all but a refresh might still be necessary if the project store has not been initialized yet. Rather than think about this long enough, I decided that it's ok that these operations are a little slow.

## Notes to reviewer
Review the output of our GitHub action 'Test & Lint' for warnings.

Please compare page load times between this branch and main.


## Related issues
This PR adds changes on top of #223, **get that merged first before even reviewing this PR**.