### PR TITLE
Update react-window to 1.8.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7868,9 +7868,9 @@
       }
     },
     "node_modules/react-window": {
-      "version": "1.8.10",
-      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.10.tgz",
-      "integrity": "sha512-Y0Cx+dnU6NLa5/EvoHukUD0BklJ8qITCtVEPY1C/nL8wwoZ0b5aEw8Ff1dOVHw7fCzMt55XfJDd8S8W8LCaUCg==",
+      "version": "1.8.11",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.11.tgz",
+      "integrity": "sha512-+SRbUVT2scadgFSWx+R1P754xHPEqvcfSfVX10QYg6POOz+WNgkN48pS+BtZNIMGiL1HYrSEiCkwsMS15QogEQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.0.0",
@@ -7880,8 +7880,8 @@
         "node": ">8.0.0"
       },
       "peerDependencies": {
-        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -9369,7 +9369,7 @@
         "next": "14.2.35",
         "react": "~18.3.1",
         "react-dom": "~18.3.1",
-        "react-window": "^1.8.10",
+        "react-window": "^1.8.11",
         "simple-git": "^3.27.0",
         "yaml": "^2.6.1",
         "zod": "^3.23.8"

--- a/webapp/CHANGELOG.md
+++ b/webapp/CHANGELOG.md
@@ -4,12 +4,16 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Update react-window from 1.8.10 to 1.8.11
+
 ## [0.9.0] - 2026-03-01
 
 ### Fixed
 
-- Reduce load times by not refreshing ProjectStore if we skipped fetch.
-- Reduce load times by not refreshing ProjectStore many times per page load.
+- Reduce load times by not refreshing ProjectStore if we skipped fetch
+- Reduce load times by not refreshing ProjectStore many times per page load
 
 ### Changed
 

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -23,7 +23,7 @@
     "next": "14.2.35",
     "react": "~18.3.1",
     "react-dom": "~18.3.1",
-    "react-window": "^1.8.10",
+    "react-window": "^1.8.11",
     "simple-git": "^3.27.0",
     "yaml": "^2.6.1",
     "zod": "^3.23.8"


### PR DESCRIPTION
## Description
This pull request updates react-window from 1.8.10 to 1.8.11

Version 1.8.11 adds compatibility with Next 15's React 19.

There is not any newer `@types/react-window` to update to. As this is a patch-level update, I guess the types are still close enough. In react-window 2, types are included and thus `@types/react-window` is discontinued.

I used npm 10.9.7 to update package-lock with `npm install`

I tested this with `npm run dev in webapp`

This branch merges with `issue-248/eslint-8` without conflicts.

## Notes to reviewer
I have reviewed the output of our GitHub action 'Test & Lint' and found no new issues.

I tested `/projects/zetkin/sv` with a projects.yaml like below

``` 
projects:
  - name: zetkin
    repo_path: ...
    base_branch: lyra
    project_path: .
    host: github.com
    owner: WULCAN
    repo: app.zetkin.org
    github_token: ...
```

* There are warnings about duplicate keys but I find those on our `main` branch too. I fix that in a separate pull request #252
* Lyra finds 0 messages and translations on first load and doesn't resolve that until its cache times out. I find the same issue on `main` and createt a separate issue #254

## Related issues
This update is a prerequisite for #149