### PR TITLE
Change key in MessageForm to index

### DIFF
--- a/webapp/CHANGELOG.md
+++ b/webapp/CHANGELOG.md
@@ -4,12 +4,16 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix warning about message id children having the same key in MessageForm
+
 ## [0.9.0] - 2026-03-01
 
 ### Fixed
 
-- Reduce load times by not refreshing ProjectStore if we skipped fetch.
-- Reduce load times by not refreshing ProjectStore many times per page load.
+- Reduce load times by not refreshing ProjectStore if we skipped fetch
+- Reduce load times by not refreshing ProjectStore many times per page load
 
 ### Changed
 

--- a/webapp/src/components/MessageForm.tsx
+++ b/webapp/src/components/MessageForm.tsx
@@ -227,7 +227,7 @@ const MessageForm: FC<MessageFormProps> = ({
                 ) : (
                   messageIdParts.map((part, i) => (
                     <Typography
-                      key={part}
+                      key={i}
                       color={
                         i === messageIdParts.length - 1
                           ? 'text.primary'


### PR DESCRIPTION
## Description
This pull request changes a key in MessageForm to an index instead of a message id part.

The values of part are not unique for the list, and React complains about it when scrolling in `/projects/[projectName]/[languageName]/`

## Screenshots
<img width="800" height="450" alt="image" src="https://github.com/user-attachments/assets/66560e0e-ef81-43d2-9619-1e76b9a1bbe3" />

## Notes to reviewer
I have reviewed the output of our GitHub action 'Test & Lint' for warnings. The warning about jest naming collision reproduces on `main` too. I fix that in a separate pull request #253

I tested `/projects/zetkin/sv` with a projects.yaml like below:
``` 
projects:
  - name: zetkin
    repo_path: ...
    base_branch: lyra
    project_path: .
    host: github.com
    owner: WULCAN
    repo: app.zetkin.org
    github_token: ...
```

## Related issues
Introduced in https://github.com/zetkin/lyra/commit/abde7e5e6611c919c8ee2f0dd15a3c40de7288bf#diff-a3f0d8865da0048545b7aa269fe1907de7b0cb07e538e73af1a08f42b5664630R186