### PR TITLE
Ignore webapp/.next for Jest

### DIFF
--- a/webapp/jest.config.js
+++ b/webapp/jest.config.js
@@ -2,6 +2,7 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  projects: ['<rootDir>'],
   moduleNameMapper: {
     '@/(.*)': '<rootDir>/src/$1',
   },

--- a/webapp/jest.config.js
+++ b/webapp/jest.config.js
@@ -2,7 +2,7 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  projects: ['<rootDir>'],
+  modulePathIgnorePatterns: ['<rootDir>/.next/'],
   moduleNameMapper: {
     '@/(.*)': '<rootDir>/src/$1',
   },


### PR DESCRIPTION
## Description
This pull request configures Jest to ignore `webapp/.next`

When not configured, and after `npm run build`, Jest finds a project under `.next/standalone/webapp` too. That triggers a warning about naming:

```
jest-haste-map: Haste module naming collision: lyra-webapp
  The following files share their name; please adjust your hasteImpl:
    * <rootDir>/package.json
    * <rootDir>/.next/standalone/webapp/package.json
```

See https://jestjs.io/docs/configuration#modulepathignorepatterns-arraystring

## Notes to reviewer
Review the output of our GitHub action 'Test & Lint' for warnings.