### PR TITLE
Check whether we have merged since last pull

### DIFF
--- a/webapp/CHANGELOG.md
+++ b/webapp/CHANGELOG.md
@@ -4,12 +4,16 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix Lyra not loading messages or translations on first clone
+
 ## [0.9.0] - 2026-03-01
 
 ### Fixed
 
-- Reduce load times by not refreshing ProjectStore if we skipped fetch.
-- Reduce load times by not refreshing ProjectStore many times per page load.
+- Reduce load times by not refreshing ProjectStore if we skipped fetch
+- Reduce load times by not refreshing ProjectStore many times per page load
 
 ### Changed
 

--- a/webapp/src/RepoGit.ts
+++ b/webapp/src/RepoGit.ts
@@ -31,7 +31,7 @@ export class RepoGit {
   } = {};
 
   private lyraConfig?: LyraConfig;
-  private lastPullTime: Date;
+  public lastPullTime: Date;
 
   private constructor(
     private readonly spConfig: ServerProjectConfig,
@@ -108,7 +108,7 @@ export class RepoGit {
    * Fetch then checkout origin/<base branch>
    * @returns true if we fetched, false if we skipped fetch
    */
-  public async fetchAndCheckoutOriginBase(): Promise<boolean> {
+  public async fetchAndCheckoutOriginBase() {
     const now = new Date();
     const age = now.getTime() - this.lastPullTime.getTime();
     if (age > this.GIT_FETCH_TTL) {
@@ -119,9 +119,7 @@ export class RepoGit {
       await this.git.fetch();
       await this.git.checkout(this.spConfig.originBaseBranch);
       this.lastPullTime = now;
-      return true;
     }
-    return false;
   }
 
   public async saveLanguageFiles(projectPath: string): Promise<string[]> {

--- a/webapp/src/dataAccess.ts
+++ b/webapp/src/dataAccess.ts
@@ -38,11 +38,11 @@ export async function accessLanguage(
   }
 
   const repoGit = await RepoGit.get(project);
-  const fetched = await repoGit.fetchAndCheckoutOriginBase();
+  await repoGit.fetchAndCheckoutOriginBase();
   const lyraConfig = await repoGit.getLyraConfig();
   const projectConfig = lyraConfig.getProjectConfigByPath(project.projectPath);
   const projectStore = await Store.getProjectStore(projectConfig);
-  if (fetched) {
+  if (!projectStore.hasMergedSince(repoGit.lastPullTime)) {
     await projectStore.refresh();
   }
   const messages = await projectStore.getMessages();
@@ -67,11 +67,11 @@ async function readProject(project: ServerProjectConfig) {
     return { languagesWithTranslations: [], messages: [], name: project.name };
   }
   const repoGit = await RepoGit.get(project);
-  const fetched = await repoGit.fetchAndCheckoutOriginBase();
+  await repoGit.fetchAndCheckoutOriginBase();
   const lyraConfig = await repoGit.getLyraConfig();
   const projectConfig = lyraConfig.getProjectConfigByPath(project.projectPath);
   const store = await Store.getProjectStore(projectConfig);
-  if (fetched) {
+  if (!store.hasMergedSince(repoGit.lastPullTime)) {
     await store.refresh();
   }
   const messages = await store.getMessages();

--- a/webapp/src/store/ProjectStore.ts
+++ b/webapp/src/store/ProjectStore.ts
@@ -79,6 +79,14 @@ export class ProjectStore {
     }
   }
 
+  public hasMergedSince(time: Date): boolean {
+    const last = this.data.timeOfLastMerge;
+    if (last === undefined) {
+      return false;
+    }
+    return last.getTime() >= time.getTime();
+  }
+
   public async refresh() {
     const fromRepo: StoreData = {
       languages: await this.translationAdapter.getTranslations(),

--- a/webapp/src/store/ProjectStore.ts
+++ b/webapp/src/store/ProjectStore.ts
@@ -8,6 +8,7 @@ import {
 } from '@/utils/adapters';
 import { StoreData } from './types';
 import mergeStoreData from './mergeStoreData';
+import { debug } from '@/utils/log';
 
 export class ProjectStore {
   private data: StoreData;
@@ -84,10 +85,11 @@ export class ProjectStore {
     if (last === undefined) {
       return false;
     }
-    return last.getTime() >= time.getTime();
+    return last >= time.getTime();
   }
 
   public async refresh() {
+    debug('refresh');
     const fromRepo: StoreData = {
       languages: await this.translationAdapter.getTranslations(),
       messages: await this.messageAdapter.getMessages(),

--- a/webapp/src/store/mergeStoreData.spec.ts
+++ b/webapp/src/store/mergeStoreData.spec.ts
@@ -157,12 +157,12 @@ describe('mergeStoreData()', () => {
   });
 
   it('updates present timeOfLastMerge', () => {
-    const before = new Date();
+    const before = new Date().getTime();
     const result = mergeStoreData(
       {
         languages: {},
         messages: [],
-        timeOfLastMerge: new Date(0),
+        timeOfLastMerge: 0,
       },
       {
         languages: {},
@@ -170,13 +170,11 @@ describe('mergeStoreData()', () => {
       },
     );
     expect(result.timeOfLastMerge).toBeDefined();
-    expect(result.timeOfLastMerge?.getTime()).toBeGreaterThanOrEqual(
-      before.getTime(),
-    );
+    expect(result.timeOfLastMerge).toBeGreaterThanOrEqual(before);
   });
 
   it('updates absent timeOfLastMerge', () => {
-    const before = new Date();
+    const before = new Date().getTime();
     const result = mergeStoreData(
       {
         languages: {},
@@ -188,9 +186,7 @@ describe('mergeStoreData()', () => {
       },
     );
     expect(result.timeOfLastMerge).toBeDefined();
-    expect(result.timeOfLastMerge?.getTime()).toBeGreaterThanOrEqual(
-      before.getTime(),
-    );
+    expect(result.timeOfLastMerge).toBeGreaterThanOrEqual(before);
   });
 });
 

--- a/webapp/src/store/mergeStoreData.spec.ts
+++ b/webapp/src/store/mergeStoreData.spec.ts
@@ -155,6 +155,43 @@ describe('mergeStoreData()', () => {
       sv: {},
     });
   });
+
+  it('updates present timeOfLastMerge', () => {
+    const before = new Date();
+    const result = mergeStoreData(
+      {
+        languages: {},
+        messages: [],
+        timeOfLastMerge: new Date(0),
+      },
+      {
+        languages: {},
+        messages: [],
+      },
+    );
+    expect(result.timeOfLastMerge).toBeDefined();
+    expect(result.timeOfLastMerge?.getTime()).toBeGreaterThanOrEqual(
+      before.getTime(),
+    );
+  });
+
+  it('updates absent timeOfLastMerge', () => {
+    const before = new Date();
+    const result = mergeStoreData(
+      {
+        languages: {},
+        messages: [],
+      },
+      {
+        languages: {},
+        messages: [],
+      },
+    );
+    expect(result.timeOfLastMerge).toBeDefined();
+    expect(result.timeOfLastMerge?.getTime()).toBeGreaterThanOrEqual(
+      before.getTime(),
+    );
+  });
 });
 
 const mockTranslation = (

--- a/webapp/src/store/mergeStoreData.spec.ts
+++ b/webapp/src/store/mergeStoreData.spec.ts
@@ -22,7 +22,8 @@ describe('mergeStoreData()', () => {
 
     const result = mergeStoreData(inMemory, fromRepo);
 
-    expect(result).toEqual(fromRepo);
+    expect(result.languages).toEqual({});
+    expect(result.messages).toEqual([]);
   });
 
   it('accepts fromRepo when inMemory is empty', () => {
@@ -41,7 +42,8 @@ describe('mergeStoreData()', () => {
     };
 
     const result = mergeStoreData(inMemory, fromRepo);
-    expect(result).toEqual(fromRepo);
+    expect(result.languages).toEqual(fromRepo.languages);
+    expect(result.messages).toEqual(fromRepo.messages);
   });
 
   it('accepts new message', () => {
@@ -68,7 +70,7 @@ describe('mergeStoreData()', () => {
     };
 
     const result = mergeStoreData(inMemory, fromRepo);
-    expect(result).toEqual(fromRepo);
+    expect(result.messages).toEqual(fromRepo.messages);
   });
 
   it('removes translations when message disappears from repo', () => {
@@ -87,7 +89,8 @@ describe('mergeStoreData()', () => {
     };
 
     const result = mergeStoreData(inMemory, fromRepo);
-    expect(result).toEqual(fromRepo);
+    expect(result.languages).toEqual(fromRepo.languages);
+    expect(result.messages).toEqual(fromRepo.messages);
   });
 
   it('retains translation from memory', () => {
@@ -110,7 +113,7 @@ describe('mergeStoreData()', () => {
     };
 
     const result = mergeStoreData(inMemory, fromRepo);
-    expect(result).toEqual(inMemory);
+    expect(result.languages).toEqual(inMemory.languages);
   });
 
   it('always returns languages, even if empty', () => {
@@ -127,7 +130,9 @@ describe('mergeStoreData()', () => {
     };
 
     const result = mergeStoreData(inMemory, fromRepo);
-    expect(result).toEqual(fromRepo);
+    expect(result.languages).toEqual({
+      sv: {},
+    });
   });
 
   it('should not return undefined if both memory and repo are falsy (undefined)', () => {
@@ -146,11 +151,8 @@ describe('mergeStoreData()', () => {
     };
 
     const result = mergeStoreData(inMemory, fromRepo);
-    expect(result).toStrictEqual({
-      languages: {
-        sv: {},
-      },
-      messages: [mockMessage('any.message.id', 'Default message')],
+    expect(result.languages).toStrictEqual({
+      sv: {},
     });
   });
 });

--- a/webapp/src/store/mergeStoreData.ts
+++ b/webapp/src/store/mergeStoreData.ts
@@ -37,5 +37,6 @@ export default function mergeStoreData(
     });
   });
 
+  output.timeOfLastMerge = new Date();
   return output;
 }

--- a/webapp/src/store/mergeStoreData.ts
+++ b/webapp/src/store/mergeStoreData.ts
@@ -37,6 +37,6 @@ export default function mergeStoreData(
     });
   });
 
-  output.timeOfLastMerge = new Date();
+  output.timeOfLastMerge = new Date().getTime();
   return output;
 }

--- a/webapp/src/store/types.ts
+++ b/webapp/src/store/types.ts
@@ -3,5 +3,5 @@ import { MessageData, TranslationMap } from '@/utils/adapters';
 export type StoreData = {
   languages: TranslationMap;
   messages: MessageData[];
-  timeOfLastMerge?: Date;
+  timeOfLastMerge?: number;
 };

--- a/webapp/src/store/types.ts
+++ b/webapp/src/store/types.ts
@@ -3,4 +3,5 @@ import { MessageData, TranslationMap } from '@/utils/adapters';
 export type StoreData = {
   languages: TranslationMap;
   messages: MessageData[];
+  timeOfLastMerge?: Date;
 };


### PR DESCRIPTION
## Description
This pull request checks whether the ProjectStore has merged with repo since last pull instead of checking whether last pull pulled. That fixes issue #254 

With this solution, RepoGit and ProjectStore stay relatively decoupled. The new time is persisted to store.json, which could be useful later on.

Later, we can improve this to track git revision instead of time.

## Changes
* Adds timeOfLastMerge to ProjectStore
* Exposes lastPullTime on RepoGit
* Changes checks for whether last pull pulled to checks whether last merge is older than last pull.

## Notes to reviewer
Review the output of our GitHub action 'Test & Lint' for warnings.

1. Run with debug logging:
```
DEBUG=1 npm run dev
```

2. Test that refresh is still skipped when fetch is skipped.
3. Test that store is refreshed after fetch.
4. Test that this works without a store.json
5. Test that this works with a store.json without timeOfLastMerge
6. Test that this works with a store.json with timeOfLastMerge

## Related issues
Resolves #254