### PR TITLE
Edit README on github_token

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,12 @@ projects:
     owner: amerharb
     repo: zetkin.app.zetkin.org
     host: github.com
-    github_token: << github token >>
+    github_token: a github token
 ```
 
 ⚠️  Note that `repo` must not have the same value for two different projects.
+
+The value for github_token should be a github token, not the literal string 'a github token' =)
 
 Multiple projects are supported, and they're all stored within the `lyra-projects` folder on the same level as the lyra repository itself.
 


### PR DESCRIPTION
This pull request edits README to show that your token should not be surrounded with `<<` and `>>`