### PR TITLE
Add json translation file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ projects:
       format: ts
       path: src # relative path of messages folder relative from above project path
     translations:
+      format: yaml # 'yaml' (default) or 'json'
       path: src/locale # relative path of translations folder relative from above project path
     languages: # list of language codes supported in the project
       - sv

--- a/webapp/src/RepoGit.ts
+++ b/webapp/src/RepoGit.ts
@@ -1,11 +1,11 @@
 import fs from 'fs/promises';
 import { Octokit } from '@octokit/rest';
 import path from 'path';
-import { stringify } from 'yaml';
 
 import { IGit } from '@/utils/git/IGit';
 import { LyraConfig } from '@/utils/lyraConfig';
 import packageJson from '../package.json';
+import serializeTranslationFile from '@/utils/serializeTranslationFile';
 import { ServerProjectConfig } from '@/utils/serverConfig';
 import { SimpleGitWrapper } from '@/utils/git/SimpleGitWrapper';
 import { unflattenObject } from '@/utils/unflattenObject';
@@ -215,22 +215,22 @@ export class RepoGit {
         const resultSourceFile = await Promise.allSettled(
           Object.entries(translationsBySourceFile).map(
             async ([sourceFile, translation]) => {
-              const yamlPath = path.join(translationsPath, sourceFile);
+              const filePath = path.join(translationsPath, sourceFile);
               const textById: Record<string, string> = {};
               Object.entries(translation).forEach(([id, textState]) => {
                 textById[id] = textState.text;
               });
-              const yamlOutput = stringify(unflattenObject(textById), {
-                doubleQuotedAsJSON: true,
-                singleQuote: true,
-              });
+              const fileOutput = serializeTranslationFile(
+                unflattenObject(textById),
+                filePath,
+              );
               try {
-                await fs.writeFile(yamlPath, yamlOutput, { flush: true });
-                info(`Successfully wrote to: ${yamlPath}`);
+                await fs.writeFile(filePath, fileOutput, { flush: true });
+                info(`Successfully wrote to: ${filePath}`);
               } catch (e) {
-                throw new WriteLanguageFileError(yamlPath, e);
+                throw new WriteLanguageFileError(filePath, e);
               }
-              paths.push(yamlPath);
+              paths.push(filePath);
             },
           ),
         );

--- a/webapp/src/RepoGit.ts
+++ b/webapp/src/RepoGit.ts
@@ -8,7 +8,7 @@ import { LyraConfig } from '@/utils/lyraConfig';
 import packageJson from '../package.json';
 import { ServerProjectConfig } from '@/utils/serverConfig';
 import { SimpleGitWrapper } from '@/utils/git/SimpleGitWrapper';
-import { unflattenTranslateIdTextState } from '@/utils/unflattenObject';
+import { unflattenObject } from '@/utils/unflattenObject';
 import { debug, error, info, warn } from '@/utils/log';
 import { WriteLanguageFileError, WriteLanguageFileErrors } from '@/errors';
 import { type TranslationMap } from '@/utils/adapters';
@@ -216,13 +216,14 @@ export class RepoGit {
           Object.entries(translationsBySourceFile).map(
             async ([sourceFile, translation]) => {
               const yamlPath = path.join(translationsPath, sourceFile);
-              const yamlOutput = stringify(
-                unflattenTranslateIdTextState(translation),
-                {
-                  doubleQuotedAsJSON: true,
-                  singleQuote: true,
-                },
-              );
+              const textById: Record<string, string> = {};
+              Object.entries(translation).forEach(([id, textState]) => {
+                textById[id] = textState.text;
+              });
+              const yamlOutput = stringify(unflattenObject(textById), {
+                doubleQuotedAsJSON: true,
+                singleQuote: true,
+              });
               try {
                 await fs.writeFile(yamlPath, yamlOutput, { flush: true });
                 info(`Successfully wrote to: ${yamlPath}`);

--- a/webapp/src/store/ProjectStore.spec.ts
+++ b/webapp/src/store/ProjectStore.spec.ts
@@ -226,7 +226,7 @@ describe('ProjectStore', () => {
       expect(actual['core.click'].sourceFile).toEqual('sv.json');
     });
 
-    it('falls back to the configured file extension for a brand new language', async () => {
+    it('falls back to the configured file extension for a brand new message', async () => {
       const store = new ProjectStore(
         {
           getMessages: async () => [

--- a/webapp/src/store/ProjectStore.spec.ts
+++ b/webapp/src/store/ProjectStore.spec.ts
@@ -192,6 +192,61 @@ describe('ProjectStore', () => {
       const actual = await store.getTranslations('sv');
       expect(actual['core.click'].sourceFile).toEqual('sv.yml');
     });
+
+    it('uses en source file extension over the configured default', async () => {
+      const store = new ProjectStore(
+        {
+          getMessages: async () => [
+            {
+              defaultMessage: 'Click',
+              id: 'core.click',
+              params: [],
+            },
+          ],
+        },
+        {
+          getTranslations: async () => ({
+            en: {
+              'core.click': {
+                sourceFile: 'en.json',
+                state: TranslateState.PUBLISHED,
+                text: 'Click',
+              },
+            },
+          }),
+        },
+        undefined,
+        'yml',
+      );
+
+      await store.refresh();
+      await store.updateTranslation('sv', 'core.click', 'Klicka');
+
+      const actual = await store.getTranslations('sv');
+      expect(actual['core.click'].sourceFile).toEqual('sv.json');
+    });
+
+    it('falls back to the configured file extension for a brand new language', async () => {
+      const store = new ProjectStore(
+        {
+          getMessages: async () => [
+            {
+              defaultMessage: 'Click',
+              id: 'core.click',
+              params: [],
+            },
+          ],
+        },
+        { getTranslations: async () => ({}) },
+        undefined,
+        'json',
+      );
+
+      await store.updateTranslation('sv', 'core.click', 'Klicka');
+
+      const actual = await store.getTranslations('sv');
+      expect(actual['core.click'].sourceFile).toEqual('sv.json');
+    });
   });
 
   it('gives full access to all languages', async () => {

--- a/webapp/src/store/ProjectStore.ts
+++ b/webapp/src/store/ProjectStore.ts
@@ -13,11 +13,13 @@ export class ProjectStore {
   private data: StoreData;
   private readonly translationAdapter: ITranslationAdapter;
   private readonly messageAdapter: IMessageAdapter;
+  private readonly newFileExtension: string;
 
   constructor(
     messageAdapter: IMessageAdapter,
     translationAdapter: ITranslationAdapter,
     initialState?: StoreData,
+    newFileExtension: string = 'yml',
   ) {
     this.data = initialState || {
       languages: {},
@@ -26,6 +28,7 @@ export class ProjectStore {
 
     this.translationAdapter = translationAdapter;
     this.messageAdapter = messageAdapter;
+    this.newFileExtension = newFileExtension;
   }
 
   async getLanguageData(): Promise<TranslationMap> {
@@ -92,16 +95,16 @@ export class ProjectStore {
   private generateSourceFile(lang: string, messageId: string): string {
     const enSourceFile = this.data.languages?.['en']?.[messageId]?.sourceFile;
     if (!enSourceFile) {
-      return `${lang}.yml`;
+      return `${lang}.${this.newFileExtension}`;
     }
     /** for example if lang = sv then replace "en" to "sv" ex. "folder1/en.yaml" -> "folder1/sv.yaml" */
     const enSourceFileArr = enSourceFile.split('/');
     const enShortFileName = enSourceFileArr.pop();
     if (!enShortFileName) {
-      return `${lang}.yml`;
+      return `${lang}.${this.newFileExtension}`;
     }
     const langFileName = enShortFileName.replace(
-      /^en\.(.+\.)*(ya?ml)$/g,
+      /^en\.(.+\.)*(ya?ml|json)$/g,
       `${lang}.$1$2`,
     );
     enSourceFileArr.push(langFileName);

--- a/webapp/src/store/Store.ts
+++ b/webapp/src/store/Store.ts
@@ -2,7 +2,7 @@ import fs from 'fs/promises';
 
 import { ProjectStore } from '@/store/ProjectStore';
 import MessageAdapterFactory from '@/utils/adapters/MessageAdapterFactory';
-import YamlTranslationAdapter from '@/utils/adapters/YamlTranslationAdapter';
+import TranslationAdapterFactory from '@/utils/adapters/TranslationAdapterFactory';
 import { LyraProjectConfig } from '@/utils/lyraConfig';
 import { StoreData } from './types';
 import { error } from '@/utils/log';
@@ -45,8 +45,9 @@ export class Store {
 
       const projectStore = new ProjectStore(
         MessageAdapterFactory.createAdapter(lyraProjectConfig),
-        new YamlTranslationAdapter(lyraProjectConfig.absTranslationsPath),
+        TranslationAdapterFactory.createAdapter(lyraProjectConfig),
         initialProjectState,
+        lyraProjectConfig.translationFileExtension,
       );
       store.addProjectStore(lyraProjectConfig.absPath, projectStore);
     }

--- a/webapp/src/utils/adapters/JsonTranslationAdapter.spec.ts
+++ b/webapp/src/utils/adapters/JsonTranslationAdapter.spec.ts
@@ -1,0 +1,121 @@
+import mock from 'mock-fs';
+import { afterEach, describe, expect, it } from '@jest/globals';
+
+import JsonTranslationAdapter from './JsonTranslationAdapter';
+import { TranslateState } from '@/utils/adapters/index';
+
+describe('JsonTranslationAdapter', () => {
+  describe('getTranslations()', () => {
+    afterEach(() => {
+      mock.restore();
+    });
+
+    it('Reads translations for multiple languages', async () => {
+      mock({
+        '/path/to/repo/locale/de.json': JSON.stringify({ no: 'Nein' }),
+        '/path/to/repo/locale/sv.json': JSON.stringify({ no: 'Nej' }),
+      });
+
+      const adapter = new JsonTranslationAdapter('/path/to/repo/locale');
+      const translations = await adapter.getTranslations();
+
+      expect(translations).toEqual({
+        de: {
+          no: {
+            sourceFile: 'de.json',
+            state: TranslateState.PUBLISHED,
+            text: 'Nein',
+          },
+        },
+        sv: {
+          no: {
+            sourceFile: 'sv.json',
+            state: TranslateState.PUBLISHED,
+            text: 'Nej',
+          },
+        },
+      });
+    });
+
+    it('Reads single language', async () => {
+      mock({
+        '/path/to/repo/locale/de.json': JSON.stringify({ no: 'Nein' }),
+      });
+
+      const adapter = new JsonTranslationAdapter('/path/to/repo/locale');
+      const translations = await adapter.getTranslations();
+
+      expect(translations).toEqual({
+        de: {
+          no: {
+            sourceFile: 'de.json',
+            state: TranslateState.PUBLISHED,
+            text: 'Nein',
+          },
+        },
+      });
+    });
+
+    it('Reads complex object for single language', async () => {
+      mock({
+        '/path/to/repo/locale/de.json': JSON.stringify({
+          options: { no: 'Nein' },
+        }),
+      });
+
+      const adapter = new JsonTranslationAdapter('/path/to/repo/locale');
+      const translations = await adapter.getTranslations();
+
+      expect(translations).toEqual({
+        de: {
+          'options.no': {
+            sourceFile: 'de.json',
+            state: TranslateState.PUBLISHED,
+            text: 'Nein',
+          },
+        },
+      });
+    });
+
+    it('Combines file path and object path for ID', async () => {
+      mock({
+        '/path/to/repo/locale/my/feature/de.json': JSON.stringify({
+          options: { no: 'Nein' },
+        }),
+      });
+
+      const adapter = new JsonTranslationAdapter('/path/to/repo/locale');
+      const translations = await adapter.getTranslations();
+
+      expect(translations).toEqual({
+        de: {
+          'my.feature.options.no': {
+            sourceFile: 'my/feature/de.json',
+            state: TranslateState.PUBLISHED,
+            text: 'Nein',
+          },
+        },
+      });
+    });
+
+    it('Does not read yaml files', async () => {
+      mock({
+        '/path/to/repo/locale/de.json': JSON.stringify({ no: 'Nein' }),
+        '/path/to/repo/locale/sv.yml': 'no: Nej',
+      });
+
+      const adapter = new JsonTranslationAdapter('/path/to/repo/locale');
+      const translations = await adapter.getTranslations();
+
+      expect(translations).toEqual({
+        de: {
+          no: {
+            sourceFile: 'de.json',
+            state: TranslateState.PUBLISHED,
+            text: 'Nein',
+          },
+        },
+      });
+    });
+  });
+});

--- a/webapp/src/utils/adapters/JsonTranslationAdapter.ts
+++ b/webapp/src/utils/adapters/JsonTranslationAdapter.ts
@@ -1,0 +1,66 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+import flattenObject from '../flattenObject';
+import { ITranslationAdapter, TranslateState, type TranslationMap } from '.';
+
+export default class JsonTranslationAdapter implements ITranslationAdapter {
+  private readonly basePath: string;
+
+  constructor(basePath: string) {
+    this.basePath = basePath;
+  }
+
+  async getTranslations(): Promise<TranslationMap> {
+    const matcher = (path: string) => path.endsWith('.json');
+
+    const map: TranslationMap = {};
+
+    for await (const fullPath of findFiles(this.basePath, matcher)) {
+      const sourceFilePath = path.relative(this.basePath, fullPath);
+      const fileName = path.basename(fullPath);
+      const pathWithoutFile = sourceFilePath.slice(0, -fileName.length);
+      const jsonBuf = await fs.readFile(fullPath);
+      const data = JSON.parse(jsonBuf.toString());
+      const flattened = flattenObject(data);
+
+      const lang = fileName.split('.')[0];
+      if (!map[lang]) {
+        map[lang] = {};
+      }
+
+      Object.entries(flattened).forEach(([key, value]) => {
+        const elements = [
+          ...pathWithoutFile.split('/'),
+          ...key.split('.'),
+        ].filter((elem) => !!elem);
+
+        const id = elements.join('.');
+
+        map[lang][id] = {
+          sourceFile: sourceFilePath,
+          state: TranslateState.PUBLISHED,
+          text: value,
+          timestamp: undefined, // maybe in future we can add a timestamp of file change
+        };
+      });
+    }
+
+    return map;
+  }
+}
+
+async function* findFiles(
+  dir: string,
+  matches: (fullFilePath: string) => boolean,
+): AsyncIterable<string> {
+  const dirEnts = await fs.readdir(dir, { withFileTypes: true });
+  for (const dirEnt of dirEnts) {
+    const fullFilePath = path.resolve(dir, dirEnt.name);
+    if (dirEnt.isDirectory()) {
+      yield* findFiles(fullFilePath, matches);
+    } else if (matches(fullFilePath)) {
+      yield fullFilePath;
+    }
+  }
+}

--- a/webapp/src/utils/adapters/TranslationAdapterFactory.ts
+++ b/webapp/src/utils/adapters/TranslationAdapterFactory.ts
@@ -1,0 +1,14 @@
+import JsonTranslationAdapter from './JsonTranslationAdapter';
+import YamlTranslationAdapter from './YamlTranslationAdapter';
+import { ITranslationAdapter } from '.';
+import { LyraProjectConfig, TranslationKind } from '../lyraConfig';
+
+export default class TranslationAdapterFactory {
+  static createAdapter(lpConfig: LyraProjectConfig): ITranslationAdapter {
+    if (lpConfig.translationKind == TranslationKind.JSON) {
+      return new JsonTranslationAdapter(lpConfig.absTranslationsPath);
+    } else {
+      return new YamlTranslationAdapter(lpConfig.absTranslationsPath);
+    }
+  }
+}

--- a/webapp/src/utils/lyraConfig.spec.ts
+++ b/webapp/src/utils/lyraConfig.spec.ts
@@ -1,7 +1,7 @@
 import mock from 'mock-fs';
 import { afterEach, describe, expect, it } from '@jest/globals';
 
-import { LyraConfig, MessageKind } from './lyraConfig';
+import { LyraConfig, MessageKind, TranslationKind } from './lyraConfig';
 import { LyraConfigReadingError, ProjectPathNotFoundError } from '@/errors';
 
 describe('LyraConfig', () => {
@@ -54,6 +54,41 @@ describe('LyraConfig', () => {
         '/path/to/repo/locale',
       );
       expect(config.projects[0].languages).toEqual(['en']); // default value
+    });
+
+    it('defaults translationKind to yaml when format is omitted', async () => {
+      mock({
+        '/path/to/repo/.lyra.yaml': [
+          'projects:',
+          '- path: .',
+          '  messages:',
+          '    format: yaml',
+          '    path: locale',
+          '  translations:',
+          '    path: locale',
+        ].join('\n'),
+      });
+      const config = await LyraConfig.readFromDir('/path/to/repo');
+      expect(config.projects[0].translationKind).toEqual(TranslationKind.YAML);
+      expect(config.projects[0].translationFileExtension).toEqual('yml');
+    });
+
+    it('reads translations.format: json from .lyra.yaml', async () => {
+      mock({
+        '/path/to/repo/.lyra.yaml': [
+          'projects:',
+          '- path: .',
+          '  messages:',
+          '    format: ts',
+          '    path: src',
+          '  translations:',
+          '    format: json',
+          '    path: locale',
+        ].join('\n'),
+      });
+      const config = await LyraConfig.readFromDir('/path/to/repo');
+      expect(config.projects[0].translationKind).toEqual(TranslationKind.JSON);
+      expect(config.projects[0].translationFileExtension).toEqual('json');
     });
 
     it('combines project path with messages path', async () => {

--- a/webapp/src/utils/lyraConfig.ts
+++ b/webapp/src/utils/lyraConfig.ts
@@ -10,9 +10,22 @@ export enum MessageKind {
   YAML = 'yaml',
 }
 
+export enum TranslationKind {
+  YAML = 'yaml',
+  JSON = 'json',
+}
+
 const KIND_BY_FORMAT_VALUE: Record<'ts' | 'yaml', MessageKind> = {
   ts: MessageKind.TS,
   yaml: MessageKind.YAML,
+};
+
+const TRANSLATION_KIND_BY_FORMAT_VALUE: Record<
+  'yaml' | 'json',
+  TranslationKind
+> = {
+  json: TranslationKind.JSON,
+  yaml: TranslationKind.YAML,
 };
 
 const lyraConfigSchema = z.object({
@@ -27,6 +40,9 @@ const lyraConfigSchema = z.object({
       }),
       path: z.string(),
       translations: z.object({
+        // defaults to 'yaml' to remain backwards compatible with configs
+        // written before JSON translation files were supported
+        format: z.optional(z.enum(['yaml', 'json'])),
         path: z.string(),
       }),
     }),
@@ -65,6 +81,10 @@ export class LyraConfig {
             messagesPath: project.messages.path,
             path: project.path,
             repoPath: repoPath,
+            translationKind:
+              TRANSLATION_KIND_BY_FORMAT_VALUE[
+                project.translations.format ?? 'yaml'
+              ],
             translationsPath: project.translations.path,
           });
         }),
@@ -94,6 +114,7 @@ export type LyraProjectConfigProps = {
   messagesPath: string;
   path: string;
   repoPath: string;
+  translationKind?: TranslationKind;
   translationsPath: string;
 };
 
@@ -103,6 +124,7 @@ export class LyraProjectConfig {
   public readonly messageKind: string;
   private readonly messagesPath: string;
   private readonly translationsPath: string;
+  public readonly translationKind: TranslationKind;
   public readonly languages: string[];
 
   constructor({
@@ -110,6 +132,7 @@ export class LyraProjectConfig {
     path,
     messageKind,
     messagesPath,
+    translationKind,
     translationsPath,
     languages,
   }: LyraProjectConfigProps) {
@@ -117,6 +140,7 @@ export class LyraProjectConfig {
     this.path = path;
     this.messageKind = messageKind;
     this.messagesPath = messagesPath;
+    this.translationKind = translationKind ?? TranslationKind.YAML;
     this.translationsPath = translationsPath;
     /*
      * Lyra was written primarily for Zetkin Generation 3
@@ -169,6 +193,11 @@ export class LyraProjectConfig {
 
   get absTranslationsPath(): string {
     return path.join(this.repoPath, this.path, this.translationsPath);
+  }
+
+  /** file extension (without leading dot) used when a new translation file is created */
+  get translationFileExtension(): string {
+    return this.translationKind === TranslationKind.JSON ? 'json' : 'yml';
   }
 
   isLanguageSupported(lang: string): boolean {

--- a/webapp/src/utils/serializeTranslationFile.spec.ts
+++ b/webapp/src/utils/serializeTranslationFile.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from '@jest/globals';
+
+import serializeTranslationFile from './serializeTranslationFile';
+
+describe('serializeTranslationFile()', () => {
+  it('serializes to YAML for a .yml path', () => {
+    const output = serializeTranslationFile({ no: 'Nein' }, 'locale/de.yml');
+
+    expect(output).toEqual('no: Nein\n');
+  });
+
+  it('serializes to YAML for a .yaml path', () => {
+    const output = serializeTranslationFile({ no: 'Nein' }, 'locale/de.yaml');
+
+    expect(output).toEqual('no: Nein\n');
+  });
+
+  it('serializes to JSON for a .json path', () => {
+    const output = serializeTranslationFile({ no: 'Nein' }, 'locale/de.json');
+
+    expect(JSON.parse(output)).toEqual({ no: 'Nein' });
+  });
+
+  it('serializes nested objects to JSON', () => {
+    const output = serializeTranslationFile(
+      { options: { no: 'Nein' } },
+      'locale/de.json',
+    );
+
+    expect(JSON.parse(output)).toEqual({ options: { no: 'Nein' } });
+  });
+});

--- a/webapp/src/utils/serializeTranslationFile.ts
+++ b/webapp/src/utils/serializeTranslationFile.ts
@@ -1,0 +1,20 @@
+import { stringify } from 'yaml';
+
+import { UnflattenObject } from './unflattenObject';
+
+/**
+ * Serialize translation data to a string, in the format implied by filePath's extension.
+ */
+export default function serializeTranslationFile(
+  data: UnflattenObject,
+  filePath: string,
+): string {
+  if (filePath.endsWith('.json')) {
+    return JSON.stringify(data, null, 2) + '\n';
+  }
+
+  return stringify(data, {
+    doubleQuotedAsJSON: true,
+    singleQuote: true,
+  });
+}

--- a/webapp/src/utils/unflattenObject.ts
+++ b/webapp/src/utils/unflattenObject.ts
@@ -1,11 +1,5 @@
-import { TextState, TranslateIdTextState } from '@/utils/adapters';
-
 export interface UnflattenObject {
   [key: string]: string | UnflattenObject;
-}
-
-export interface UnflattenTranslateIdTextState {
-  [key: string]: TextState | UnflattenTranslateIdTextState;
 }
 
 /**
@@ -23,29 +17,6 @@ export function unflattenObject(obj: Record<string, string>): UnflattenObject {
       } else {
         current[keys[i]] = current[keys[i]] || {};
         current = current[keys[i]] as UnflattenObject;
-      }
-    }
-  }
-  return result;
-}
-
-/**
- * Unflatten TranslateIdTextState, a flat object with TextState values.
- * ex: { 'a.b.c': TextState } => { a: { b: { c: TextState } } }
- */
-export function unflattenTranslateIdTextState(
-  obj: TranslateIdTextState,
-): UnflattenTranslateIdTextState {
-  const result: UnflattenTranslateIdTextState = {};
-  for (const key in obj) {
-    const keys = key.split('.');
-    let current: UnflattenTranslateIdTextState = result;
-    for (let i = 0; i < keys.length; i++) {
-      if (i === keys.length - 1) {
-        current[keys[i]] = obj[key];
-      } else {
-        current[keys[i]] = current[keys[i]] || {};
-        current = current[keys[i]] as UnflattenTranslateIdTextState;
       }
     }
   }


### PR DESCRIPTION
## Description
This PR adds support for reading/writing json translation files and fixes a bug when serializing files. 


## Changes
[Add a list of features added/changed, bugs fixed etc]

* Fixes a bug that would serialize the state into the output yaml file:
  ```
  no:
    state: PUBLISHED
    text: Nein
  ```
* Adds config support for json translation files
* Adds json adapter for reading+finding json translation files
* Adds json serializer


## AI Usage

I did use Claude to make this PR.


## Notes to reviewer

Let me know if I should split off the bugfix into a separate PR. I chose to keep it in here, since it is also involved with serializing translation files and it is a pretty small fix. 

I added tests to test the new functionality. 

## Related issues
Resolves https://github.com/zetkin/lyra/issues/260
